### PR TITLE
make stringprep usage optional

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -41,7 +41,11 @@ Objectives of *node-xmpp:*
 ## Dependencies
 
 * [node-expat](http://github.com/astro/node-expat)
-* [node-stringprep](http://github.com/astro/node-stringprep)
+* [ltx](http://github.com/astro/ltx)
+
+Optional
+
+* [node-stringprep](http://github.com/astro/node-stringprep): for [icu](http://icu-project.org/)-based string normalization.
 
 
 ## Design
@@ -93,4 +97,3 @@ stanza, before sending it out the wire.
 
 * More documentation
 * More tests (Using [Vows](http://vowsjs.org/))
-

--- a/lib/xmpp/jid.js
+++ b/lib/xmpp/jid.js
@@ -1,7 +1,13 @@
-var StringPrep = require('node-stringprep').StringPrep;
-var nameprep = new StringPrep('nameprep');
-var nodeprep = new StringPrep('nodeprep');
-var resourceprep = new StringPrep('resourceprep');
+try {
+    var StringPrep = require('node-stringprep').StringPrep;
+    var nameprep = new StringPrep('nameprep');
+    var nodeprep = new StringPrep('nodeprep');
+    var resourceprep = new StringPrep('resourceprep');
+} catch(ex) {
+    var nameprep = null;
+    var nodeprep = null;
+    var resourceprep = null;
+}
 
 function JID(a, b, c) {
     if (a && b == null && c == null) {
@@ -58,13 +64,13 @@ JID.prototype.equals = function(other) {
  * Setters that do stringprep normalization.
  **/
 JID.prototype.setUser = function(user) {
-    this.user = user && nodeprep.prepare(user);
+    this.user = user && (nodeprep ? nodeprep.prepare(user) : user);
 };
 JID.prototype.setDomain = function(domain) {
-    this.domain = domain && nameprep.prepare(domain);
+    this.domain = domain && (nameprep ? nameprep.prepare(domain) : domain);
 };
 JID.prototype.setResource = function(resource) {
-    this.resource = resource && resourceprep.prepare(resource);
+    this.resource = resource && (resourceprep ? resourceprep.prepare(resource) : resource);
 };
 
 exports.JID = JID;

--- a/lib/xmpp/router.js
+++ b/lib/xmpp/router.js
@@ -4,8 +4,12 @@ var JID = require('./jid');
 var ltx = require('ltx');
 var StreamShaper = require('./../stream_shaper');
 var IdleTimeout = require('./../idle_timeout');
-var StringPrep = require('node-stringprep').StringPrep;
-var nameprep = new StringPrep('nameprep');
+try {
+    var StringPrep = require('node-stringprep').StringPrep;
+    var nameprep = new StringPrep('nameprep');
+} catch (ex) {
+    var nameprep = null;
+}
 
 var NS_XMPP_SASL = 'urn:ietf:params:xml:ns:xmpp-sasl';
 var NS_XMPP_STANZAS = 'urn:ietf:params:xml:ns:xmpp-stanzas';
@@ -304,8 +308,10 @@ DomainContext.prototype.verifyIncoming = function(fromDomain, inStream, dbKey) {
 
     // these are needed before for removeListener()
     var onVerified = function(from, to, id, isValid) {
-        from = nameprep.prepare(from);
-        to = nameprep.prepare(to);
+        if (nameprep) {
+            from = nameprep.prepare(from);
+            to = nameprep.prepare(to);
+        }
         if (from !== fromDomain ||
             to !== self.domain ||
             id != inStream.streamId)
@@ -415,9 +421,10 @@ Router.prototype.acceptConnection = function(socket) {
 
     // incoming server wants to verify an outgoing connection of ours
     inStream.addListener('dialbackVerify', function(from, to, id, key) {
-        from = nameprep.prepare(from);
-        to = nameprep.prepare(to);
-
+        if (nameprep) {
+            from = nameprep.prepare(from);
+            to = nameprep.prepare(to);
+        }
         if (self.hasContext(to)) {
             self.getContext(to).verifyDialback(from, id, key, function(isValid) {
                 // look if this was a connection of ours
@@ -429,9 +436,10 @@ Router.prototype.acceptConnection = function(socket) {
     });
     // incoming connection wants to get verified
     inStream.addListener('dialbackKey', function(from, to, key) {
-        from = nameprep.prepare(from);
-        to = nameprep.prepare(to);
-
+        if (nameprep) {
+            from = nameprep.prepare(from);
+            to = nameprep.prepare(to);
+        }
         if (self.hasContext(to)) {
             // trigger verification via outgoing connection
             self.getContext(to).verifyIncoming(from, inStream, key);
@@ -455,7 +463,9 @@ Router.prototype.setupStream = function(stream) {
  * Create domain context & register a stanza listener callback
  */
 Router.prototype.register = function(domain, listener) {
-    domain = nameprep.prepare(domain);
+    if (nameprep) {
+        domain = nameprep.prepare(domain);
+    }
     this.getContext(domain).stanzaListener = listener;
 };
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
 ,"description": "Idiomatic XMPP client, component & server library for node.js"
 ,"author": "Stephan Maka"
 ,"dependencies": {"node-expat": "1.1.0"
-		 ,"node-stringprep": "0.0.2"
 		 ,"ltx": "0.0.1"
 		 }
 ,"repositories": [{"type": "git"


### PR DESCRIPTION
"npm install" fails on the node-stringprep dependency on Mac OS X.  I played with trying to get node-stringprep to build, but couldn't, either with the icu installs with "brew" or with MacPorts.

From what I understand stringprep is only being used for case-normalization (and possibly other types of normalization?) of international domain names. As a result I've tried to make the usage of stringprep optional here.

Would you be interested in merging this patch? I'd be happy to adjust it if it doesn't work for you as is.

Cheers,
Trent
