### PR TITLE
nodejs v0.4.8 doesn't have pair._ssl anymore. Changed behavior with backw

### DIFF
--- a/lib/starttls.js
+++ b/lib/starttls.js
@@ -24,7 +24,8 @@ module.exports = function starttls(socket, options, cb) {
   var cleartext = pipe(pair, socket);
 
   pair.on('secure', function() {
-    var verifyError = pair._ssl.verifyError();
+    var ssl = pair._ssl || pair.ssl;
+    var verifyError = ssl.verifyError();
 
     if (verifyError) {
       cleartext.authorized = false;


### PR DESCRIPTION
nodejs v0.4.8 doesn't have pair._ssl anymore. Changed behavior with backwards support as well.
