### PR TITLE
Little error in send_message_component.js example

### DIFF
--- a/examples/send_message_component.js
+++ b/examples/send_message_component.js
@@ -21,7 +21,7 @@ c.addListener('online',
 						     from: c.jid,
 						     type: 'chat'}).
 				  c('body').
-				  t(argv[4]));
+				  t(argv[6]));
 		       });
 
 		   // nodejs has nothing left to do and will exit


### PR DESCRIPTION
The wrong argument was taken and send in the send_message_component.js example.
Probably due to a copy/past from send_message.js ;-)

By the way node-xmpp is awesome, thanks.
