### PR TITLE
Fix the issue of memory leak

### DIFF
--- a/lib/idle_timeout.js
+++ b/lib/idle_timeout.js
@@ -15,21 +15,20 @@ exports.attach = function(stream, timeout) {
             clearTimeout(timer);
         timer = setTimeout(emitTimeout, timeout);
     };
-
+    
     var oldWrite = stream.write;
     stream.write = function() {
         updateTimer();
         oldWrite.apply(this, arguments);
     };
-    stream.addListener('data', updateTimer);
-    stream.addListener('close', function() {
-		if (timer)
-		    clearTimeout(timer);
-	    stream.write = oldWrite;
-    });
-    stream.addListener('end', function() {
+    var cleanup = function() {
     	if (timer)
-    	    clearTimeout(timer);
-        stream.write = oldWrite;
-    });
+    		clearTimeout(timer);
+    	if ( oldWrite != stream.write) {
+        	oldWrite = stream.write;
+    	}
+    };
+    stream.addListener('data', updateTimer);
+    stream.addListener('close', cleanup);
+    stream.addListener('end', cleanup);
 };


### PR DESCRIPTION
I found the following:
if client doesn't end the connection, the "close" event will not be fire in the server

As a result, it is not enough for the idle timer to listen to the "close" event, but "end" event of socket as well.
so that there is no memory leak even if client doesn't end the connection.
