### PR TITLE
emit conn-close on connection end event.

### DIFF
--- a/lib/xmpp/connection.js
+++ b/lib/xmpp/connection.js
@@ -270,7 +270,7 @@ Connection.prototype.end = function() {
             this.socket.end();
         }
     }
-    this.emit('conn-close');
+    this.emit('close');
 };
 
 /**


### PR DESCRIPTION
Hi Astro,

I found the node-xmpp is great most of the time. One thing I think we can improve is to detect socket disconnect and report to caller. I made a little change in connection.js and it seems working for me. 
   Usage example of to listen 'conn-close' event at Client.
   cl = new xmpp.Client()
    cl.on('conn-close', function() {
      console.log('connection ends');
    });

I think doing auto-reconnect directly at Client is also possible. Able to report disconnect looks a MUST to have to me.

Cheers,
George
