### PR TITLE
Variable username doesn't exist

### DIFF
--- a/lib/xmpp/c2s.js
+++ b/lib/xmpp/c2s.js
@@ -211,7 +211,7 @@ C2SStream.prototype.onRegistration = function(stanza) {
     else if (stanza.attrs.type === 'set') {
         var jid = new JID(register.getChildText('username'), this.server.options.domain)
         self.server.emit('register', { jid: jid,
-                                       username: username,
+                                       username: register.getChildText('username'),
                                        password: register.getChildText('password'),
                                        client: self },
                          function(error) {


### PR DESCRIPTION
Hi,

A bug in c2s causes the registration to fail and crash because a variable "username" is accessed that doesn't exit. This one line patch should fix it.
