### PR TITLE
Fixed bug in user registration

### DIFF
--- a/lib/xmpp/c2s.js
+++ b/lib/xmpp/c2s.js
@@ -210,7 +210,7 @@ C2SStream.prototype.onRegistration = function(stanza) {
     }
     else if (stanza.attrs.type === 'set') {
         var jid = new JID(register.getChildText('username'), this.server.options.domain)
-        self.server.emit('register', { jid: jid,
+        this.emit('register', { jid: jid,
                                        username: register.getChildText('username'),
                                        password: register.getChildText('password'),
                                        client: self },


### PR DESCRIPTION
Hi,

I fixed two bugs in c2s wicht prevented `C2SStream.prototype.onRegistration`:
1. A variable `username` that didn't exist was called 
2. The `register` event was not emitted properly 

Cheers,
Frane
