### PR TITLE
Reconnection timeout is being reset in the wrong place

### DIFF
--- a/lib/xmpp/connection.js
+++ b/lib/xmpp/connection.js
@@ -53,7 +53,7 @@ Connection.prototype.allowTLS = true;
 */
 Connection.prototype.setupStream = function() {
     var self = this;
-    this.reconnectDelay = 0;
+
     this.socket.addListener('data', function(data) {
         self.onData(data);
     });
@@ -171,6 +171,9 @@ Connection.prototype.stopParser = function() {
 };
 
 Connection.prototype.startStream = function() {
+    /* reset reconnect delay */
+    this.reconnectDelay = 0;
+    
     var attrs = {};
     for(var k in this.xmlns) {
         if (this.xmlns.hasOwnProperty(k)) {


### PR DESCRIPTION
Currently the reconnectionDelay is being reset at every reconnection attempt. It should only be reset when a reconnect is successful. 
