### PR TITLE
Readme to include dependent packages for expat

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -63,9 +63,9 @@ With package manager [npm](http://npmjs.org/):
 * [node-expat](http://github.com/astro/node-expat)
 Note: You will likely need to install the libraries for node-expat.
   * Ubuntu / Debian derivatives:
-    zipp@prospekt:~/node-xmpp$ sudo yum install libexpat1-dev
+    `zipp@prospekt:~/node-xmpp$ sudo yum install libexpat1-dev`
   * Centos / Red Hat derivatives:
-    [zipp@dominion ~]# sudo yum install expat-devel
+    `[zipp@dominion ~]# sudo yum install expat-devel`
 * [ltx](http://github.com/astro/ltx)
 
 Optional


### PR DESCRIPTION
I've been asked on #node.js about the dependencies for expat, and figured it may be wise to include installation instructions for the node-expat headers in the readme.
