### PR TITLE
Linking registration reply to callback

### DIFF
--- a/lib/xmpp/c2s.js
+++ b/lib/xmpp/c2s.js
@@ -213,6 +213,7 @@ C2SStream.prototype.onRegistration = function(stanza) {
             c("instructions").t("Choose a username and password for use with this service. ").up().
             c("username").up().
             c("password");
+	self.send(reply);
     }
     else if (stanza.attrs.type === 'set') {
         var jid = new JID(register.getChildText('username'), this.server.options.domain)
@@ -229,9 +230,9 @@ C2SStream.prototype.onRegistration = function(stanza) {
                 reply.attrs.type = "error";
                 reply.c("error", { code: '' + error.code, type: error.type }).c('text', { xmlns: "urn:ietf:params:xml:ns:xmpp-stanzas" }).t(error.message);
             }
+	    self.send(reply);	
         });
     }
-    self.send(reply);
 };
 
 C2SStream.prototype.onBind = function(stanza) {


### PR DESCRIPTION
On receiving a registration stanza we enter C2SStream.prototype.onRegistration and we were sending success reply for stanza.attrs.type === 'set' case delinking it to the value of 'error' in the callback to 'register' event.
Making self.send(reply) part of callback mitigates this bug. 
