### PR TITLE
Update a link in README for node-xmpp-bosh

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -70,7 +70,7 @@ Optional
 
 ## Related Libraries
 
-* [node-xmpp-bosh](http://code.google.com/p/node-xmpp-bosh/): BOSH & websocket server (connection manager)
+* [node-xmpp-bosh](https://github.com/dhruvbird/node-xmpp-bosh): BOSH & websocket server (connection manager)
 * [node-xmpp-via-bosh](https://github.com/anoopc/node-xmpp-via-bosh/): BOSH client connections from node.js
 * [node-simple-xmpp](https://github.com/arunoda/node-simple-xmpp/): Simpler high-level client layer
 * [xmpp-server](https://github.com/superfeedr/xmpp-server/): Reusable XMPP server on top of node-xmpp


### PR DESCRIPTION
node-xmpp-bosh have been moved from google code to a github, update a README.markdown in accordance
