### PR TITLE
Fixed Mechanism missing prototype method `authAttrs` issue.

### DIFF
--- a/lib/xmpp/sasl.js
+++ b/lib/xmpp/sasl.js
@@ -50,7 +50,7 @@ exports.availableMechanisms = availableMechanisms;
 function Mechanism() {
 }
 util.inherits(Mechanism, EventEmitter);
-Mechanism.authAttrs = function() {
+Mechanism.prototype.authAttrs = function() {
     return {};
 };
 


### PR DESCRIPTION
It seems the Mechanism in `sasl.js` missing the `authAttrs` prototype method: it incorrectly become a function method, and will not be inherited by other mechanisms. 

I notice that after I tested the simple `send_message` example and got errors like "TypeError: Object #<Plain> has no method 'authAttrs'" . 
