### PR TITLE
Define default authAttrs method on Mechanism.prototype

### DIFF
--- a/lib/xmpp/sasl.js
+++ b/lib/xmpp/sasl.js
@@ -50,7 +50,7 @@ exports.availableMechanisms = availableMechanisms;
 function Mechanism() {
 }
 util.inherits(Mechanism, EventEmitter);
-Mechanism.authAttrs = function() {
+Mechanism.prototype.authAttrs = function() {
     return {};
 };
 


### PR DESCRIPTION
Plain SASL mechanism does not have an authAttrs method so it throws an error on
client.js line 188 when Plain mechanism is used.

Fixes #104
