### PR TITLE
Add link to Junction

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -69,6 +69,7 @@ Optional
 
 
 ## Related Libraries
+
 * [Junction](https://github.com/jaredhanson/junction): An extensible XMPP middleware layer
 * [node-xmpp-bosh](http://code.google.com/p/node-xmpp-bosh/): BOSH & websocket server (connection manager)
 * [node-xmpp-via-bosh](https://github.com/anoopc/node-xmpp-via-bosh/): BOSH client connections from node.js


### PR DESCRIPTION
I recently discovered the great [Junction](https://github.com/jaredhanson/junction) project by @jaredhanson which adds a middleware layer for XMPP (similar to the approach Connect takes for HTTP). Felt it'd be worth mentioning in the node-xmpp README :)
