### PR TITLE
Set isSecure back to false when closing secure connection. Fixes #2

### DIFF
--- a/lib/xmpp/connection.js
+++ b/lib/xmpp/connection.js
@@ -206,6 +206,7 @@ Connection.prototype.setSecure = function(credentials, isServer) {
     });
     ct.on('close', function() {
 	self.onClose();
+	self.isSecure = false;
     });
 
     // The socket is now the cleartext stream


### PR DESCRIPTION
This fixes reconnections to servers using TLS.

Note that this fix is based on v0.3.2 (since that's what we are currently using), but should be easily ported forward to v0.4.2.
