### PR TITLE
 Fixed: "TypeError: Cannot call method 'end' of undefined"

### DIFF
--- a/lib/xmpp/connection.js
+++ b/lib/xmpp/connection.js
@@ -297,7 +297,8 @@ Connection.prototype.rmXmlns = function(stanza) {
  */
 Connection.prototype.onEnd = function() {
     this.stopParser();
-    this.socket.end();
+    if (this.socket)
+        this.socket.end();
 };
 
 /**


### PR DESCRIPTION
 Fixed: "TypeError: Cannot call method 'end' of undefined" on lib/xmpp/connection.js:300

Altered Connection.prototype.onEnd() to check that `this.socket` is defined before calling this.socket.end().

Example error stacktrace:

```
/var/node/node_modules/node-xmpp/lib/xmpp/connection.js:300
    this.socket.end();
                ^
TypeError: Cannot call method 'end' of undefined
    at Connection.onEnd (/var/node/node_modules/node-xmpp/lib/xmpp/connection.js:300:17)
    at CleartextStream.<anonymous> (/var/node/node_modules/node-xmpp/lib/xmpp/connection.js:61:14)
    at CleartextStream.EventEmitter.emit (events.js:117:20)
    at _stream_readable.js:910:16
    at process._tickCallback (node.js:415:13)
```
