### PR TITLE
Removing the listener/emiter of #120

### DIFF
--- a/lib/xmpp/session.js
+++ b/lib/xmpp/session.js
@@ -68,9 +68,9 @@ function Session(opts) {
 	            if (opts.credentials) {
 	                self.connection.credentials = crypto.createCredentials(opts.credentials);
 	            }
-	            self.connection.socket.on("connect", function() {
+	            /*self.connection.socket.on("connect", function() {
                         self.connection.emit('connect')
-                    })
+                    })*/
                     self.connection.socket.connect(opts.port || 5222, opts.host);
     		}
 	    } else if (!SRV) {


### PR DESCRIPTION
the #120 modification disconnects the socket before the tls handshake when trying to connect to facebook chat
