### PR TITLE
Fix in-band registration ({register: true})

### DIFF
--- a/lib/xmpp/client.js
+++ b/lib/xmpp/client.js
@@ -102,6 +102,8 @@ Client.prototype.onStanza = function(stanza) {
         stanza.is('features', Connection.NS_STREAM)) {
         this.streamFeatures = stanza;
         this.useFeatures();
+    } else if (this.state == STATE_PREAUTH) {
+        this.emit('stanza:preauth', stanza);
     } else if (this.state == STATE_AUTH) {
         if (stanza.is('challenge', NS_XMPP_SASL)) {
             var challengeMsg = decode64(stanza.getText());
@@ -252,7 +254,7 @@ Client.prototype.doRegister = function() {
 	    }
 	}
     };
-    this.on('stanza', onReply);
+    this.on('stanza:preauth', onReply);
 };
 
 Client.prototype.registerSaslMechanism = function () {


### PR DESCRIPTION
Due to some commit, in-band registration is broken in the current node-xmpp. The problem is that the `onStanza` method of `xmpp.Client` doesn't emit "stanza" events in `STATE_PREAUTH` phase, but that `doRegister` depends on such an event being fired to detect a registration reply IQ. I fixed this by emitting a new event type "stanza:preauth" in the `STATE_PREAUTH` and using that in `doRegister`.
