### PR TITLE
jshint fixes

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -5,7 +5,7 @@ module.exports = function(grunt) {
     grunt.initConfig({
         pkg: grunt.file.readJSON('package.json'),
         jshint: {
-            allFiles: ['gruntfile.js', 'lib/**/*.js', 'examples/**/*.js'],
+            allFiles: ['gruntfile.js', 'lib/**/*.js'],
             options: {
                 jshintrc: '.jshintrc',
             }

--- a/lib/node-xmpp-browserify.js
+++ b/lib/node-xmpp-browserify.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var Connection = require('./xmpp/connection');
 var Client = require('./xmpp/client').Client;
 var JID = require('./xmpp/jid');

--- a/lib/starttls.js
+++ b/lib/starttls.js
@@ -18,7 +18,7 @@
 //    })
 //  })
 
-var tls = require('tls')
+var tls = require('tls');
 
 module.exports = function starttls(socket, opts, cb) {
     var pair = tls.createSecurePair(
@@ -26,48 +26,51 @@ module.exports = function starttls(socket, opts, cb) {
         opts.requestCert, opts.rejectUnauthorized
     )
 
-    var cleartext = pipe(pair, socket)
+    var cleartext = pipe(pair, socket);
 
     pair.on('secure', function() {
-        var ssl = pair._ssl || pair.ssl
-        var verifyError = ssl.verifyError()
+        var ssl = pair._ssl || pair.ssl;
+        var verifyError = ssl.verifyError();
 
         if (verifyError) {
-            cleartext.authorized = false
-            cleartext.authorizationError = verifyError
+            cleartext.authorized = false;
+            cleartext.authorizationError = verifyError;
         } else {
-            cleartext.authorized = true
+            cleartext.authorized = true;
         }
 
-        if (cb) cb()
+        if (cb) {
+            cb()
+        }
     })
 
-    cleartext._controlReleased = true
-    return cleartext
+    cleartext._controlReleased = true;
+    return cleartext;
 }
 
 function pipe(pair, socket) {
-    pair.encrypted.pipe(socket)
-    socket.pipe(pair.encrypted)
+    pair.encrypted.pipe(socket);
+    socket.pipe(pair.encrypted);
 
-    pair.fd = socket.fd
-    var cleartext = pair.cleartext
-    cleartext.socket = socket
-    cleartext.encrypted = pair.encrypted
-    cleartext.authorized = false
+    pair.fd = socket.fd;
+    var cleartext = pair.cleartext;
+    cleartext.socket = socket;
+    cleartext.encrypted = pair.encrypted;
+    cleartext.authorized = false;
 
     function onerror(e) {
-        if (cleartext._controlReleased)
-            cleartext.emit('error', e)
+        if (cleartext._controlReleased) {
+            cleartext.emit('error', e);
+        }
     }
 
     function onclose() {
-        socket.removeListener('error', onerror)
-        socket.removeListener('close', onclose)
+        socket.removeListener('error', onerror);
+        socket.removeListener('close', onclose);
     }
 
-    socket.on('error', onerror)
-    socket.on('close', onclose)
+    socket.on('error', onerror);
+    socket.on('close', onclose);
 
-    return cleartext
+    return cleartext;
 }

--- a/lib/stream_shaper.js
+++ b/lib/stream_shaper.js
@@ -6,19 +6,23 @@
  * @param {Number} rateLimit B/ms or KB/s
  */
 exports.attach = function(stream, rateLimit) {
-    var timer
+    var timer;
     stream.rateLimit = rateLimit // makes it readjustable after attachment
     stream.addListener('data', function(data) {
-        if (timer) clearTimeout(timer)
-        stream.pause()
-        var sleep = Math.floor(data.length / stream.rateLimit)
+        if (timer) {
+            clearTimeout(timer);
+        }
+        stream.pause();
+        var sleep = Math.floor(data.length / stream.rateLimit);
         timer = setTimeout(function() {
-            timer = undefined
-            stream.resume()
-        }, sleep)
+            timer = undefined;
+            stream.resume();
+        }, sleep);
     })
     stream.addListener('close', function() {
         // don't let the last timeout inhibit node shutdown
-        if (timer) clearTimeout(timer)
+        if (timer) {
+            clearTimeout(timer);
+        }
     })
 }

--- a/lib/xmpp.js
+++ b/lib/xmpp.js
@@ -1,1 +1,1 @@
-module.exports = require('./node-xmpp')
+module.exports = require('./node-xmpp');

--- a/lib/xmpp/bosh.js
+++ b/lib/xmpp/bosh.js
@@ -1,8 +1,9 @@
-var EventEmitter = require('events').EventEmitter;
-var util = require('util');
-var request = require('request');
-var ltx = require('ltx');
+'use strict';
 
+var EventEmitter = require('events').EventEmitter,
+    util = require('util'),
+    request = require('request'),
+    ltx = require('ltx');
 
 function BOSHConnection(opts) {
     var that = this;
@@ -11,45 +12,45 @@ function BOSHConnection(opts) {
     this.boshURL = opts.boshURL;
     this.jid = opts.jid;
     this.xmlnsAttrs = {
-    xmlns: "http://jabber.org/protocol/httpbind",
-    'xmlns:xmpp': "urn:xmpp:xbosh",
-    'xmlns:stream': "http://etherx.jabber.org/streams"
+        xmlns: 'http://jabber.org/protocol/httpbind',
+        'xmlns:xmpp': 'urn:xmpp:xbosh',
+        'xmlns:stream': 'http://etherx.jabber.org/streams'
     };
     if (opts.xmlns)
-    for(var prefix in opts.xmlns)
-        if (prefix)
-        this.xmlnsAttrs["xmlns:" + prefix] = opts.xmlns[prefix];
-        else
-        this.xmlnsAttrs["xmlns"] = opts.xmlns[prefix];
+        for (var prefix in opts.xmlns)
+            if (prefix)
+                this.xmlnsAttrs['xmlns:' + prefix] = opts.xmlns[prefix];
+            else
+                this.xmlnsAttrs.xmlns = opts.xmlns[prefix];
     this.currentRequests = 0;
     this.queue = [];
     this.rid = Math.ceil(Math.random() * 9999999999);
 
     this.request({
-    to: this.jid.domain,
-    ver: "1.6",
-    wait: "10",
-    hold: "1",
-    content: this.contentType
+        to: this.jid.domain,
+        ver: '1.6',
+        wait: '10',
+        hold: '1',
+        content: this.contentType
     }, [], function(err, bodyEl) {
-    if (err) {
-        that.emit('error', err);
-    } else if (bodyEl && bodyEl.attrs) {
-        that.sid = bodyEl.attrs.sid;
-        that.maxRequests = parseInt(bodyEl.attrs.requests, 10) || 2;
-        if (that.sid && that.maxRequests > 0) {
-        that.emit('connect');
-        that.processResponse(bodyEl);
-        process.nextTick(that.mayRequest.bind(that));
-        } else
-        that.emit('error', "Invalid parameters");
-    }
+        if (err) {
+            that.emit('error', err);
+        } else if (bodyEl && bodyEl.attrs) {
+            that.sid = bodyEl.attrs.sid;
+            that.maxRequests = parseInt(bodyEl.attrs.requests, 10) || 2;
+            if (that.sid && that.maxRequests > 0) {
+                that.emit('connect');
+                that.processResponse(bodyEl);
+                process.nextTick(that.mayRequest.bind(that));
+            } else
+                that.emit('error', 'Invalid parameters');
+        }
     });
 }
 util.inherits(BOSHConnection, EventEmitter);
 exports.BOSHConnection = BOSHConnection;
 
-BOSHConnection.prototype.contentType = "text/xml; charset=utf-8";
+BOSHConnection.prototype.contentType = 'text/xml; charset=utf-8';
 
 BOSHConnection.prototype.send = function(stanza) {
     this.queue.push(stanza.root());
@@ -58,15 +59,15 @@ BOSHConnection.prototype.send = function(stanza) {
 
 BOSHConnection.prototype.processResponse = function(bodyEl) {
     if (bodyEl && bodyEl.children) {
-    for(var i = 0; i < bodyEl.children.length; i++) {
-        var child = bodyEl.children[i];
-        if (child.name && child.attrs && child.children)
-        this.emit('stanza', child);
-    }
+        for (var i = 0; i < bodyEl.children.length; i++) {
+            var child = bodyEl.children[i];
+            if (child.name && child.attrs && child.children)
+                this.emit('stanza', child);
+        }
     }
     if (bodyEl && bodyEl.attrs.type === 'terminate') {
-    this.emit('error', new Error(bodyEl.attrs.condition || "Session terminated"));
-    this.emit('close');
+        this.emit('error', new Error(bodyEl.attrs.condition || 'Session terminated'));
+        this.emit('close');
     }
 };
 
@@ -77,26 +78,27 @@ BOSHConnection.prototype.mayRequest = function() {
     this.sid &&
     /* We can only receive when one request is in flight */
     (this.currentRequests === 0 ||
-     /* Is there something to send, and are we allowed? */
-     ((this.queue.length > 0 && this.currentRequests < this.maxRequests))
+        /* Is there something to send, and are we allowed? */
+        ((this.queue.length > 0 && this.currentRequests < this.maxRequests))
     );
-    if (!canRequest)
-    return;
+    if (!canRequest) {
+        return;
+    }
 
     var stanzas = this.queue;
     this.queue = [];
     this.rid++;
     this.request({}, stanzas, function(err, bodyEl) {
-    if (err) {
-        that.emit('error', err);
-        that.emit('close');
-        delete that.sid;
-    } else {
-        if (bodyEl)
-        that.processResponse(bodyEl);
-
-        process.nextTick(that.mayRequest.bind(that));
-    }
+        if (err) {
+            that.emit('error', err);
+            that.emit('close');
+            delete that.sid;
+        } else {
+            if (bodyEl) {
+                that.processResponse(bodyEl);
+            }
+            process.nextTick(that.mayRequest.bind(that));
+        }
     });
 };
 
@@ -104,19 +106,22 @@ BOSHConnection.prototype.end = function(stanzas) {
     var that = this;
 
     stanzas = stanzas || [];
-    if (typeof stanzas !== 'array')
-    stanzas = [stanzas];
+    if (typeof stanzas !== 'array') {
+        stanzas = [stanzas];
+    }
 
     stanzas = this.queue.concat(stanzas);
     this.queue = [];
     this.rid++;
-    this.request({ type: 'terminate' }, stanzas, function(err, bodyEl) {
-    if (bodyEl)
-        that.processResponse(bodyEl);
-
-    that.emit('end');
-    that.emit('close');
-    delete that.sid;
+    this.request({
+        type: 'terminate'
+    }, stanzas, function(err, bodyEl) {
+        if (bodyEl) {
+            that.processResponse(bodyEl);
+        }
+        that.emit('end');
+        that.emit('close');
+        delete that.sid;
     });
 };
 
@@ -127,47 +132,51 @@ BOSHConnection.prototype.request = function(attrs, children, cb, retry) {
     retry = retry || 0;
 
     attrs.rid = this.rid.toString();
-    if (this.sid)
-    attrs.sid = this.sid;
-
-    for(var k in this.xmlnsAttrs)
-    attrs[k] = this.xmlnsAttrs[k];
+    if (this.sid) {
+        attrs.sid = this.sid;
+    }
+    for (var k in this.xmlnsAttrs) {
+        attrs[k] = this.xmlnsAttrs[k];
+    }
     var boshEl = new ltx.Element('body', attrs);
-    for(var i = 0; i < children.length; i++)
-    boshEl.cnode(children[i]);
+    for (var i = 0; i < children.length; i++) {
+        boshEl.cnode(children[i]);
+    }
 
     request({
-    uri: this.boshURL,
-    method: 'POST',
-    headers: {
-        "Content-Type": this.contentType
-    },
-    body: boshEl.toString()
+        uri: this.boshURL,
+        method: 'POST',
+        headers: {
+            'Content-Type': this.contentType
+        },
+        body: boshEl.toString()
     }, function(err, res, body) {
-    that.currentRequests--;
+        that.currentRequests--;
 
-    if (err) {
-        if (retry < that.maxHTTPRetries)
-        return that.request(attrs, children, cb, retry + 1);
-        else
-        return cb(err);
-    }
-    if (res.statusCode < 200 || res.statusCode >= 400)
-        return cb(new Error("HTTP status " + res.statusCode));
+        if (err) {
+            if (retry < that.maxHTTPRetries) {
+                return that.request(attrs, children, cb, retry + 1);
+            } else {
+                return cb(err);
+            }
+        }
+        if (res.statusCode < 200 || res.statusCode >= 400) {
+            return cb(new Error('HTTP status ' + res.statusCode));
+        }
+        var bodyEl;
+        try {
+            bodyEl = ltx.parse(body);
+        } catch (e) {
+            return cb(e);
+        }
 
-    var bodyEl;
-    try {
-        bodyEl = ltx.parse(body);
-    } catch(e) {
-        return cb(e);
-    }
-
-    if (bodyEl && bodyEl.attrs.type === 'terminate')
-        cb(new Error(bodyEl.attrs.condition));
-    else if (bodyEl)
-        cb(null, bodyEl);
-    else
-        cb(new Error('no <body/>'));
+        if (bodyEl && bodyEl.attrs.type === 'terminate') {
+            cb(new Error(bodyEl.attrs.condition));
+        } else if (bodyEl) {
+            cb(null, bodyEl);
+        } else {
+            cb(new Error('no <body/>'));
+        }
     });
     this.currentRequests++;
 };

--- a/lib/xmpp/bosh_server.js
+++ b/lib/xmpp/bosh_server.js
@@ -1,29 +1,29 @@
 'use strict';
 
-var EventEmitter = require('events').EventEmitter
-  , util = require('util')
-  , ltx = require('ltx')
+var EventEmitter = require('events').EventEmitter,
+    util = require('util'),
+    ltx = require('ltx');
 
 
-var NS_HTTPBIND = 'http://jabber.org/protocol/httpbind'
+var NS_HTTPBIND = 'http://jabber.org/protocol/httpbind';
 
 function parseBody(stream, cb) {
-    var parser = new ltx.Parser()
+    var parser = new ltx.Parser();
     stream.on('data', function(data) {
-        parser.write(data)
-    })
+        parser.write(data);
+    });
     stream.on('end', function() {
-        parser.end()
-    })
+        parser.end();
+    });
     stream.on('error', function(e) {
-        cb(e)
-    })
+        cb(e);
+    });
     parser.on('tree', function(bodyEl) {
-        cb(null, bodyEl)
-    })
+        cb(null, bodyEl);
+    });
     parser.on('error', function(e) {
-        cb(e)
-    })
+        cb(e);
+    });
 }
 
 /**
@@ -31,61 +31,66 @@ function parseBody(stream, cb) {
  * large setups.
  */
 function BOSHServer() {
-    this.sessions = {}
+    this.sessions = {};
 }
 
-util.inherits(BOSHServer, EventEmitter)
+util.inherits(BOSHServer, EventEmitter);
 
 /**
  * *YOU* need to check the path before passing to this function.
  */
 BOSHServer.prototype.handleHTTP = function(req, res) {
-    var self = this
+    var self = this;
     if (req.method === 'POST') {
         parseBody(req, function(error, bodyEl) {
-            if (error ||
-                !bodyEl || !bodyEl.attrs || !bodyEl.is ||
-                !bodyEl.is('body', NS_HTTPBIND)
-            ) {
-                res.writeHead(400, { 'Content-Type': 'text/plain' })
-                res.end(error.message || error.stack || 'Error')
-                return
+            if (error || !bodyEl || !bodyEl.attrs || !bodyEl.is || !bodyEl.is('body', NS_HTTPBIND)) {
+                res.writeHead(400, {
+                    'Content-Type': 'text/plain'
+                });
+                res.end(error.message || error.stack || 'Error');
+                return;
             }
 
-            var session
-            var sid = bodyEl.attrs.sid
+            var session;
+            var sid = bodyEl.attrs.sid;
             if (sid) {
                 session = self.sessions[sid]
                 if (session) {
-                    session.handleHTTP(
-                        { req: req, res: res, bodyEl: bodyEl }
-                    )
+                    session.handleHTTP({
+                        req: req,
+                        res: res,
+                        bodyEl: bodyEl
+                    });
                 } else {
                     res.writeHead(
-                        404, { 'Content-Type': 'text/plain' }
-                    )
-                    res.end('BOSH session not found')
+                        404, {
+                            'Content-Type': 'text/plain'
+                        }
+                    );
+                    res.end('BOSH session not found');
                 }
             } else {
                 /* No sid: create session */
                 do {
-                    session = new BOSHServerSession(
-                        { req: req, res: res, bodyEl: bodyEl }
-                    )
+                    session = new BOSHServerSession({
+                        req: req,
+                        res: res,
+                        bodyEl: bodyEl
+                    });
                 } while (self.sessions.hasOwnProperty(session.sid))
-                self.sessions[session.sid] = session
+                self.sessions[session.sid] = session;
                 /* Hook for destruction */
                 session.on('close', function() {
-                    delete self.sessions[session.sid]
+                    delete self.sessions[session.sid];
                 })
-                self.emit('connect', session)
+                self.emit('connect', session);
             }
         })
-    //} else if (false && req.method === 'PROPFIND') {
-    /* TODO: CORS preflight request */
+        //} else if (false && req.method === 'PROPFIND') {
+        /* TODO: CORS preflight request */
     } else {
-        res.writeHead(400)
-        res.end()
+        res.writeHead(400);
+        res.end();
     }
 }
 
@@ -94,7 +99,7 @@ function generateSid() {
     for (var i = 0; i < 32; i++) {
         sid += String.fromCharCode(48 + Math.floor(Math.random() * 10))
     }
-    return sid
+    return sid;
 }
 
 /**
@@ -116,30 +121,32 @@ function BOSHServerSession(opts) {
             }
         }
     }
-    this.streamAttrs = opts.streamAttrs || {}
-    this.handshakeAttrs = opts.bodyEl.attrs
+    this.streamAttrs = opts.streamAttrs || {};
+    this.handshakeAttrs = opts.bodyEl.attrs;
 
-    this.sid = generateSid()
-    this.nextRid = parseInt(opts.bodyEl.attrs.rid, 10) + 1
-    this.wait = parseInt(opts.bodyEl.attrs.wait || '30', 10)
-    this.hold = parseInt(opts.bodyEl.attrs.hold || '1', 10)
-    this.inQueue = {}
-    this.outQueue = []
-    this.stanzaQueue = []
+    this.sid = generateSid();
+    this.nextRid = parseInt(opts.bodyEl.attrs.rid, 10) + 1;
+    this.wait = parseInt(opts.bodyEl.attrs.wait || '30', 10);
+    this.hold = parseInt(opts.bodyEl.attrs.hold || '1', 10);
+    this.inQueue = {};
+    this.outQueue = [];
+    this.stanzaQueue = [];
 
-    this.respond(opts.res, { sid: this.sid })
+    this.respond(opts.res, {
+        sid: this.sid
+    });
 
-    this.maySetConnectionTimeout()
+    this.maySetConnectionTimeout();
 
     // Let someone hook to 'connect' event before emitting 'streamStart'
-    process.nextTick(this.startParser.bind(this))
+    process.nextTick(this.startParser.bind(this));
 }
 
-util.inherits(BOSHServerSession, EventEmitter)
+util.inherits(BOSHServerSession, EventEmitter);
 
 /* Should cause <stream:features/> to be sent. */
 BOSHServerSession.prototype.startParser = function() {
-    this.emit('streamStart', this.handshakeAttrs)
+    this.emit('streamStart', this.handshakeAttrs);
 }
 
 BOSHServerSession.prototype.handleHTTP = function(opts) {
@@ -147,31 +154,32 @@ BOSHServerSession.prototype.handleHTTP = function(opts) {
         // Already queued? Replace with this request
         var oldOpts = this.inQueue[opts.bodyEl.attrs.rid]
         oldOpts.res.writeHead(
-            403,
-            { 'Content-Type': 'text/plain' }
-        )
-        oldOpts.res.end('Request replaced by same RID')
+            403, {
+                'Content-Type': 'text/plain'
+            }
+        );
+        oldOpts.res.end('Request replaced by same RID');
     } else if (parseInt(opts.bodyEl.attrs.rid, 10) < parseInt(this.nextRid, 10)) {
         // This req has already been processed.
-        this.outQueue.push(opts)
+        this.outQueue.push(opts);
         return
     }
 
     if (this.connectionTimeout) {
-        clearTimeout(this.connectionTimeout)
-        delete this.connectionTimeout
+        clearTimeout(this.connectionTimeout);
+        delete this.connectionTimeout;
     }
 
     // Set up timeout:
-    var self = this
+    var self = this;
     opts.timer = setTimeout(function() {
-        delete opts.timer
-        self.onReqTimeout(opts.bodyEl.attrs.rid)
+        delete opts.timer;
+        self.onReqTimeout(opts.bodyEl.attrs.rid);
     }, this.wait * 1000)
 
     // Process...
-    this.inQueue[opts.bodyEl.attrs.rid] = opts
-    process.nextTick(this.workInQueue.bind(this))
+    this.inQueue[opts.bodyEl.attrs.rid] = opts;
+    process.nextTick(this.workInQueue.bind(this));
 }
 
 BOSHServerSession.prototype.workInQueue = function() {
@@ -180,110 +188,114 @@ BOSHServerSession.prototype.workInQueue = function() {
         return
     }
 
-    var self = this
-    var opts = this.inQueue[this.nextRid]
-    delete this.inQueue[this.nextRid]
-    this.nextRid++
+    var self = this;
+    var opts = this.inQueue[this.nextRid];
+    delete this.inQueue[this.nextRid];
+    this.nextRid++;
 
     opts.bodyEl.children.forEach(function(stanza) {
-        self.emit('stanza', stanza)
-    })
+        self.emit('stanza', stanza);
+    });
 
     // Input process, retain response for sending stanzas
-    this.outQueue.push(opts)
+    this.outQueue.push(opts);
 
     if (opts.bodyEl.attrs.type !== 'terminate') {
         process.nextTick(function() {
             self.workOutQueue()
             self.workInQueue()
-        })
+        });
     } else {
         for (var i = 0; i < this.outQueue.length; i++) {
             opts = this.outQueue[i]
             if (opts.timer) clearTimeout(opts.timer)
-            this.respond(opts.res, { type: 'terminate' }, [])
+            this.respond(opts.res, {
+                type: 'terminate'
+            }, [])
         }
-        this.outQueue = []
-        this.emit('end')
-        this.emit('close')
+        this.outQueue = [];
+        this.emit('end');
+        this.emit('close');
     }
 }
 
 BOSHServerSession.prototype.workOutQueue = function() {
     if ((this.stanzaQueue.length < 1) &&
         (this.outQueue.length > 0)) {
-        this.emit('drain')
+        this.emit('drain');
         return
     } else if (this.outQueue.length < 1) {
         return
     }
-    var stanzas = this.stanzaQueue
-    this.stanzaQueue = []
-    var opts = this.outQueue.shift()
+    var stanzas = this.stanzaQueue;
+    this.stanzaQueue = [];
+    var opts = this.outQueue.shift();
 
     if (opts.timer) {
-        clearTimeout(opts.timer)
-        delete opts.timer
+        clearTimeout(opts.timer);
+        delete opts.timer;
     }
 
-    this.respond(opts.res, {}, stanzas)
+    this.respond(opts.res, {}, stanzas);
 
-    this.maySetConnectionTimeout()
+    this.maySetConnectionTimeout();
 }
 
 BOSHServerSession.prototype.maySetConnectionTimeout = function() {
     if (this.outQueue.length < 1) {
-        var self = this
+        var self = this;
         this.connectionTimeout = setTimeout(function() {
-            self.emit('error', new Error('Session timeout'))
-            self.emit('close')
-        }, 60 * 1000)
+            self.emit('error', new Error('Session timeout'));
+            self.emit('close');
+        }, 60 * 1000);
     }
 }
 
 BOSHServerSession.prototype.send = function(stanza) {
-    this.stanzaQueue.push(stanza.root())
+    this.stanzaQueue.push(stanza.root());
 
-    process.nextTick(this.workOutQueue.bind(this))
+    process.nextTick(this.workOutQueue.bind(this));
     // indicate if we flush:
-    return this.outQueue.length > 0
+    return this.outQueue.length > 0;
 }
 
 BOSHServerSession.prototype.onReqTimeout = function(rid) {
-    var opts
+    var opts;
     if ((opts = this.inQueue[rid])) {
-        delete this.inQueue[rid]
+        delete this.inQueue[rid];
     } else {
         for (var i = 0; i < this.outQueue.length; i++) {
-            if (this.outQueue[i].bodyEl.attrs.rid === rid) break
+            if (this.outQueue[i].bodyEl.attrs.rid === rid) break;
         }
 
         if (i < this.outQueue.length) {
-            opts = this.outQueue[i]
-            this.outQueue.splice(i, 1)
+            opts = this.outQueue[i];
+            this.outQueue.splice(i, 1);
         } else {
-            console.warn('Spurious timeout for BOSH rid', rid)
-            return
+            console.warn('Spurious timeout for BOSH rid', rid);
+            return;
         }
     }
-    this.respond(opts.res, {})
+    this.respond(opts.res, {});
 }
 
 BOSHServerSession.prototype.respond = function(res, attrs, children) {
     res.writeHead(
-        200,
-        { 'Content-Type': 'application/xml; charset=utf-8' }
+        200, {
+            'Content-Type': 'application/xml; charset=utf-8'
+        }
     )
     for (var k in this.xmlnsAttrs) {
-        attrs[k] = this.xmlnsAttrs[k]
+        attrs[k] = this.xmlnsAttrs[k];
     }
-    var bodyEl = new ltx.Element('body', attrs)
-    if (children)
+    var bodyEl = new ltx.Element('body', attrs);
+    if (children) {
         children.forEach(bodyEl.cnode.bind(bodyEl))
+    }
     bodyEl.write(function(s) {
-        res.write(s)
+        res.write(s);
     })
-    res.end()
+    res.end();
 }
 
-exports.BOSHServer = BOSHServer
+exports.BOSHServer = BOSHServer;

--- a/lib/xmpp/c2s.js
+++ b/lib/xmpp/c2s.js
@@ -1,22 +1,22 @@
 'use strict';
 
-var EventEmitter = require('events').EventEmitter
-  , Connection = require('./connection')
-  , JID = require('./jid').JID
-  , ltx = require('ltx')
-  , util = require('util')
-  , crypto = require('crypto')
-  , net = require('net')
-  , sasl = require('./sasl')
-  , fs = require('fs')
+var EventEmitter = require('events').EventEmitter,
+    Connection = require('./connection'),
+    JID = require('./jid').JID,
+    ltx = require('ltx'),
+    util = require('util'),
+    crypto = require('crypto'),
+    net = require('net'),
+    sasl = require('./sasl'),
+    fs = require('fs');
 
-var NS_CLIENT = 'jabber:client'
-var NS_XMPP_SASL = 'urn:ietf:params:xml:ns:xmpp-sasl'
-var NS_XMPP_TLS = 'urn:ietf:params:xml:ns:xmpp-tls'
-var NS_REGISTER = 'jabber:iq:register'
-var NS_SESSION = 'urn:ietf:params:xml:ns:xmpp-session'
-var NS_BIND = 'urn:ietf:params:xml:ns:xmpp-bind'
-var NS_STANZAS = 'urn:ietf:params:xml:ns:xmpp-stanzas'
+var NS_CLIENT = 'jabber:client';
+var NS_XMPP_SASL = 'urn:ietf:params:xml:ns:xmpp-sasl';
+var NS_XMPP_TLS = 'urn:ietf:params:xml:ns:xmpp-tls';
+var NS_REGISTER = 'jabber:iq:register';
+var NS_SESSION = 'urn:ietf:params:xml:ns:xmpp-session';
+var NS_BIND = 'urn:ietf:params:xml:ns:xmpp-bind';
+var NS_STANZAS = 'urn:ietf:params:xml:ns:xmpp-stanzas';
 
 /**
  * params:
@@ -33,41 +33,43 @@ var NS_STANZAS = 'urn:ietf:params:xml:ns:xmpp-stanzas'
  *   options.tls.certPath : path to certificate
  */
 function C2SServer(options) {
-    var self = this
-    this.options = {}
-    if (options) this.options = options
-    this.availableSaslMechanisms = []
-    this.c2sPort = null
+    var self = this;
+    this.options = {};
+    if (options) {
+        this.options = options
+    }
+    this.availableSaslMechanisms = [];
+    this.c2sPort = null;
 
     // don't allow anybody by default when using client cert auth
     if ((this.options.requestCert) &&
         (this.options.rejectUnauthorized !== false)) {
-        this.options.rejectUnauthorized = true
+        this.options.rejectUnauthorized = true;
     }
 
     /* And now start listening to connections on the
      * port provided as an option.
      */
     if (this.options.autostart !== false) {
-        var port = this.options.port || this.C2S_PORT
-        var bindAddress =this.options.bindAddress || '::'
+        var port = this.options.port || this.C2S_PORT;
+        var bindAddress = this.options.bindAddress || '::';
         this.c2sPort = net.createServer(function(inStream) {
-            self.acceptConnection(inStream)
+            self.acceptConnection(inStream);
         }).listen(port, bindAddress)
     }
 
     // Load TLS key material
     if (this.options.tls) {
-        var details = this.options.tls
-        details.key = details.key || fs.readFileSync(details.keyPath, 'ascii')
-        details.cert = details.cert || fs.readFileSync(details.certPath, 'ascii')
-        this.credentials = crypto.createCredentials(details)
+        var details = this.options.tls;
+        details.key = details.key || fs.readFileSync(details.keyPath, 'ascii');
+        details.cert = details.cert || fs.readFileSync(details.certPath, 'ascii');
+        this.credentials = crypto.createCredentials(details);
     }
 }
 
-util.inherits(C2SServer, EventEmitter)
+util.inherits(C2SServer, EventEmitter);
 
-C2SServer.prototype.C2S_PORT = 5222
+C2SServer.prototype.C2S_PORT = 5222;
 
 /**
  * Called upon TCP connection from client. */
@@ -78,113 +80,129 @@ C2SServer.prototype.acceptConnection = function(socket) {
         socket: socket,
         server: this
     })
-    this.emit('connect', stream)
+    this.emit('connect', stream);
     socket.addListener('error', function() {})
     stream.addListener('error', function() {})
 }
 
 C2SServer.prototype.registerSaslMechanism = function() {
-    var args = arguments.length > 0 ? Array.prototype.slice.call(arguments) : []
-    this.availableSaslMechanisms = this.availableSaslMechanisms.concat(args)
+    var args = arguments.length > 0 ? Array.prototype.slice.call(arguments) : [];
+    this.availableSaslMechanisms = this.availableSaslMechanisms.concat(args);
 }
 
 C2SServer.prototype.shutdown = function() {
 
     // we have to shutdown all connections
-    this.emit('shutdown')
+    this.emit('shutdown');
 
     // shutdown server
-    this.c2sPort.close()
+    this.c2sPort.close();
 }
 
 // TODO: must accept a Connection or BOSHSession instead of socket
 // remove inheritance here too.
 function C2SStream(opts) {
-    var self = this
-    this.authenticated = false
-    this.server = opts.server
+    var self = this;
+    this.authenticated = false;
+    this.server = opts.server;
 
     this.connection = opts.connection || new Connection.Connection({
         rejectUnauthorized: opts.rejectUnauthorized,
         requestCert: opts.requestCert,
         socket: opts.socket
-    })
-    if (this.connection.xmlns)
-        this.connection.xmlns[''] = NS_CLIENT
-    this.connection.streamAttrs.version = '1.0'
-    this.connection.streamAttrs.id = generateId()
+    });
+    if (this.connection.xmlns) {
+        this.connection.xmlns[''] = NS_CLIENT;
+    }
+    this.connection.streamAttrs.version = '1.0';
+    this.connection.streamAttrs.id = generateId();
 
     this.connection.addListener('streamStart', function(streamAttrs) {
-        self.serverdomain = streamAttrs.to
-        self.connection.streamAttrs.from = streamAttrs.to
-        self.startStream()
-    })
+        self.serverdomain = streamAttrs.to;
+        self.connection.streamAttrs.from = streamAttrs.to;
+        self.startStream();
+    });
 
     this.connection.addListener('stanza', function(stanza) {
-        self.onStanza(stanza)
+        self.onStanza(stanza);
     })
 
     this.connection.addListener('end', function() {
-        self.emit('end')
+        self.emit('end');
     })
     this.connection.addListener('close', function() {
-        self.emit('close')
+        self.emit('close');
     })
     this.connection.addListener('error', function(e) {
-        self.emit('error', e)
+        self.emit('error', e);
     })
 
     // if the server shuts down, we close all connections
     if (this.server) {
         this.server.addListener('shutdown', function() {
-            if (this.connection) this.connection.end()
+            if (this.connection) {
+                this.connection.end();
+            }
         })
     }
-    return self
+    return self;
 }
 
-util.inherits(C2SStream, Connection.Connection)
+util.inherits(C2SStream, Connection.Connection);
 
 C2SStream.prototype.send = function(stanza) {
-    if (stanza.root) stanza = stanza.root()
-    this.connection.send(stanza)
+    if (stanza.root) {
+        stanza = stanza.root();
+    }
+    this.connection.send(stanza);
 }
 
 C2SStream.prototype.startStream = function() {
-    if (this.connection.startStream)
-        this.connection.startStream()
-    this.sendFeatures()
+    if (this.connection.startStream) {
+        this.connection.startStream();
+    }
+    this.sendFeatures();
 }
 
 C2SStream.prototype.sendFeatures = function() {
-    var features = new ltx.Element('stream:features')
+    var features = new ltx.Element('stream:features');
     if (!this.authenticated) {
         if (this.server) {
             // TLS
             if (this.server.options.tls && !this.connection.isSecure) {
-                features.c('starttls', { xmlns: NS_XMPP_TLS }).c('required')
+                features.c('starttls', {
+                    xmlns: NS_XMPP_TLS
+                }).c('required')
             }
             this.mechanisms = sasl.availableMechanisms(
-                this.server.availableSaslMechanisms)
+                this.server.availableSaslMechanisms);
         } else {
-            this.mechanisms = sasl.availableMechanisms()
+            this.mechanisms = sasl.availableMechanisms();
         }
 
         var mechanismsEl = features.c(
-            'mechanisms', { xmlns: NS_XMPP_SASL })
+            'mechanisms', {
+                xmlns: NS_XMPP_SASL
+            });
         this.mechanisms.forEach(function(mech) {
             mechanismsEl.c('mechanism').t(mech.name)
-        })
+        });
     } else {
-        features.c('bind', { xmlns: NS_BIND })
-        features.c('session', { xmlns: NS_SESSION })
+        features.c('bind', {
+            xmlns: NS_BIND
+        });
+        features.c('session', {
+            xmlns: NS_SESSION
+        });
     }
-    this.send(features)
+    this.send(features);
 }
 
 C2SStream.prototype.onStanza = function(stanza) {
-    var bind
-    if (this.jid) stanza.attrs.from = this.jid.toString()
+    var bind;
+    if (this.jid) {
+        stanza.attrs.from = this.jid.toString();
+    }
 
     if (stanza.is('starttls', NS_XMPP_TLS)) {
         this.send(new ltx.Element('proceed', {
@@ -216,11 +234,11 @@ C2SStream.prototype.onStanza = function(stanza) {
  * @param  Object authRequest obejct with credentials like {user: 'bob', password: 'secret'}
  */
 C2SStream.prototype.authenticate = function(user) {
-    var self = this
+    var self = this;
     var jid = new JID(user.username, this.serverdomain ?
         this.serverdomain.toString() : '')
-    user.jid = jid
-    user.client = this
+    user.jid = jid;
+    user.client = this;
 
     // emit event
     this.emit(
@@ -248,14 +266,14 @@ C2SStream.prototype.authenticate = function(user) {
 }
 
 C2SStream.prototype.onAuth = function(stanza) {
-    var self = this
+    var self = this;
 
     var matchingMechs = this.mechanisms.filter(function(mech) {
-        return mech.name === stanza.attrs.mechanism
+        return mech.name === stanza.attrs.mechanism;
     })
 
     if (matchingMechs[0]) {
-        this.mechanism = matchingMechs[0]
+        this.mechanism = matchingMechs[0];
         this.mechanism.extractSasl(
             decode64(stanza.getText()),
             function(user) {
@@ -272,11 +290,14 @@ C2SStream.prototype.onAuth = function(stanza) {
 }
 
 C2SStream.prototype.onRegistration = function(stanza) {
-    var self = this
-    var register = stanza.getChild('query', NS_REGISTER)
-    var reply = new ltx.Element('iq', { type: 'result' })
-    if (stanza.attrs.id)
-        reply.attrs.id = stanza.attrs.id
+    var self = this;
+    var register = stanza.getChild('query', NS_REGISTER);
+    var reply = new ltx.Element('iq', {
+        type: 'result'
+    });
+    if (stanza.attrs.id) {
+        reply.attrs.id = stanza.attrs.id;
+    }
 
     if (stanza.attrs.type === 'get') {
         var instructions = 'Choose a username and password for use ' +
@@ -284,14 +305,13 @@ C2SStream.prototype.onRegistration = function(stanza) {
         reply.c('query', {
             xmlns: NS_REGISTER
         })
-        .c('instructions').t(instructions).up()
-        .c('username').up()
-        .c('password')
+            .c('instructions').t(instructions).up()
+            .c('username').up()
+            .c('password');
     } else if (stanza.attrs.type === 'set') {
         var jid = new JID(register.getChildText('username'), this.server.options.domain)
         this.emit(
-            'register',
-            {
+            'register', {
                 jid: jid,
                 username: register.getChildText('username'),
                 password: register.getChildText('password'),
@@ -299,15 +319,17 @@ C2SStream.prototype.onRegistration = function(stanza) {
             },
             function(error) {
                 if (!error) {
-                    self.emit('registration-success', self.jid)
+                    self.emit('registration-success', self.jid);
                 } else {
-                    self.emit('registration-failure', jid)
-                    reply.attrs.type = 'error'
+                    self.emit('registration-failure', jid);
+                    reply.attrs.type = 'error';
                     reply.c(
-                        'error',
-                        { code: '' + error.code, type: error.type }
-                    ).c('text', { xmlns: NS_STANZAS })
-                    .t(error.message)
+                        'error', {
+                            code: '' + error.code,
+                            type: error.type
+                        }).c('text', {
+                            xmlns: NS_STANZAS
+                        }).t(error.message);
                 }
             })
     }
@@ -315,39 +337,46 @@ C2SStream.prototype.onRegistration = function(stanza) {
 }
 
 C2SStream.prototype.onBind = function(stanza) {
-    var bind = stanza.getChild('bind', NS_BIND)
-    var resource
+    var bind = stanza.getChild('bind', NS_BIND);
+    var resource;
     if ((resource = bind.getChild('resource', NS_BIND))) {
-        this.jid.setResource(resource.getText())
+        this.jid.setResource(resource.getText());
     } else {
-        this.jid.setResource(generateId())
+        this.jid.setResource(generateId());
     }
 
     this.send(new ltx.Element(
-        'iq',
-        { type: 'result', id: stanza.attrs.id }
-    ).c('bind', { xmlns: NS_BIND }).c('jid').t(this.jid.toString()))
+        'iq', {
+            type: 'result',
+            id: stanza.attrs.id
+        }).c('bind', {
+            xmlns: NS_BIND
+        }).c('jid')
+        .t(this.jid.toString()));
 }
 
 C2SStream.prototype.onSession = function(stanza) {
     this.send(new ltx.Element(
-        'iq',
-        { type: 'result', id: stanza.attrs.id }
-    ).c('session', { xmlns: NS_SESSION }))
-    this.emit('online')
+        'iq', {
+            type: 'result',
+            id: stanza.attrs.id
+        }).c('session', {
+            xmlns: NS_SESSION
+        }));
+    this.emit('online');
 }
 
 function generateId() {
-    var r = new Buffer(16)
+    var r = new Buffer(16);
     for (var i = 0; i < r.length; i++) {
         r[i] = 48 + Math.floor(Math.random() * 10) // '0'..'9'
     }
-    return r.toString()
+    return r.toString();
 }
 
 function decode64(encoded) {
-    return (new Buffer(encoded, 'base64')).toString('utf8')
+    return (new Buffer(encoded, 'base64')).toString('utf8');
 }
 
-exports.C2SServer = C2SServer
-exports.C2SStream = C2SStream
+exports.C2SServer = C2SServer;
+exports.C2SStream = C2SStream;

--- a/lib/xmpp/client.js
+++ b/lib/xmpp/client.js
@@ -1,52 +1,54 @@
 'use strict';
 
-var Session = require('./session').Session
-  , Connection = require('./connection')
-  , JID = require('./jid').JID
-  , ltx = require('ltx')
-  , sasl = require('./sasl')
-  , util = require('util')
+var Session = require('./session').Session,
+    Connection = require('./connection'),
+    JID = require('./jid').JID,
+    ltx = require('ltx'),
+    sasl = require('./sasl'),
+    util = require('util');
 
-var NS_CLIENT = 'jabber:client'
-var NS_REGISTER = 'jabber:iq:register'
-var NS_XMPP_SASL = 'urn:ietf:params:xml:ns:xmpp-sasl'
-var NS_XMPP_BIND = 'urn:ietf:params:xml:ns:xmpp-bind'
-var NS_XMPP_SESSION = 'urn:ietf:params:xml:ns:xmpp-session'
+var NS_CLIENT = 'jabber:client';
+var NS_REGISTER = 'jabber:iq:register';
+var NS_XMPP_SASL = 'urn:ietf:params:xml:ns:xmpp-sasl';
+var NS_XMPP_BIND = 'urn:ietf:params:xml:ns:xmpp-bind';
+var NS_XMPP_SESSION = 'urn:ietf:params:xml:ns:xmpp-session';
 
-var STATE_PREAUTH = 0
-  , STATE_AUTH = 1
-  , STATE_AUTHED = 2
-  , STATE_BIND = 3
-  , STATE_SESSION = 4
-  , STATE_ONLINE = 5
-var IQID_SESSION = 'sess'
-  , IQID_BIND = 'bind'
+var STATE_PREAUTH = 0,
+    STATE_AUTH = 1,
+    STATE_AUTHED = 2,
+    STATE_BIND = 3,
+    STATE_SESSION = 4,
+    STATE_ONLINE = 5;
+
+var IQID_SESSION = 'sess',
+    IQID_BIND = 'bind';
 
 
-var decode64, encode64, Buffer
+var decode64, encode64, Buffer;
+
 if (typeof btoa === 'undefined') {
-    var btoa = null
-    var atob = null
+    var btoa = null;
+    var atob = null;
 }
 
 if (typeof btoa === 'function') {
     decode64 = function(encoded) {
-        return atob(encoded)
+        return atob(encoded);
     }
 } else {
     Buffer = require('buffer').Buffer
     decode64 = function(encoded) {
-        return (new Buffer(encoded, 'base64')).toString('utf8')
+        return (new Buffer(encoded, 'base64')).toString('utf8');
     }
 }
 if (typeof atob === 'function') {
     encode64 = function(decoded) {
-        return btoa(decoded)
+        return btoa(decoded);
     }
 } else {
-    Buffer = require('buffer').Buffer
+    Buffer = require('buffer').Buffer;
     encode64 = function(decoded) {
-        return (new Buffer(decoded, 'utf8')).toString('base64')
+        return (new Buffer(decoded, 'utf8')).toString('base64');
     }
 }
 
@@ -97,38 +99,38 @@ if (typeof atob === 'function') {
  *
  */
 function Client(opts) {
-    var self = this
+    var self = this;
 
-    opts.xmlns = NS_CLIENT
-    self.state = STATE_PREAUTH
+    opts.xmlns = NS_CLIENT;
+    self.state = STATE_PREAUTH;
     /*jshint camelcase: false */
-    delete self.did_bind
-    delete self.did_session
+    delete self.did_bind;
+    delete self.did_session;
 
-    Session.call(this, opts)
+    Session.call(this, opts);
 
     // If server and client have multiple possible auth mechanisms
     // we try to select the preferred one
     if (opts.preferred) {
-        this.preferredSaslMechanism = opts.preferred
+        this.preferredSaslMechanism = opts.preferred;
     } else {
-        this.preferredSaslMechanism = 'DIGEST-MD5'
+        this.preferredSaslMechanism = 'DIGEST-MD5';
     }
 
-    this.availableSaslMechanisms = sasl.detectMechanisms(opts)
+    this.availableSaslMechanisms = sasl.detectMechanisms(opts);
 
 
-    this.state = STATE_PREAUTH
+    this.state = STATE_PREAUTH;
     this.addListener('end', function() {
-        self.state = STATE_PREAUTH
-        self.emit('offline')
+        self.state = STATE_PREAUTH;
+        self.emit('offline');
     })
     this.on('close', function() {
-        self.state = STATE_PREAUTH
-    })
+        self.state = STATE_PREAUTH;
+    });
 }
 
-util.inherits(Client, Session)
+util.inherits(Client, Session);
 
 Client.prototype.onStanza = function(stanza) {
     /* Actually, we shouldn't wait for <stream:features/> if
@@ -136,63 +138,67 @@ Client.prototype.onStanza = function(stanza) {
        these days anyway? */
     if ((this.state !== STATE_ONLINE) &&
         stanza.is('features', Connection.NS_STREAM)) {
-        this.streamFeatures = stanza
-        this.useFeatures()
+        this.streamFeatures = stanza;
+        this.useFeatures();
     } else if (this.state === STATE_PREAUTH) {
-        this.emit('stanza:preauth', stanza)
+        this.emit('stanza:preauth', stanza);
     } else if (this.state === STATE_AUTH) {
         if (stanza.is('challenge', NS_XMPP_SASL)) {
-            var challengeMsg = decode64(stanza.getText())
-            var responseMsg = encode64(this.mech.challenge(challengeMsg))
+            var challengeMsg = decode64(stanza.getText());
+            var responseMsg = encode64(this.mech.challenge(challengeMsg));
             var response = new ltx.Element(
-                'response', { xmlns: NS_XMPP_SASL }
-            ).t(responseMsg)
-            this.send(response)
+                'response', {
+                    xmlns: NS_XMPP_SASL
+                }
+            ).t(responseMsg);
+            this.send(response);
         } else if (stanza.is('success', NS_XMPP_SASL)) {
-            this.mech = null
-            this.state = STATE_AUTHED
-            if (this.connection.startParser)
-                this.connection.startParser()
-            if (this.connection.startStream)
-                this.connection.startStream()
+            this.mech = null;
+            this.state = STATE_AUTHED;
+            if (this.connection.startParser) {
+                this.connection.startParser();
+            }
+            if (this.connection.startStream) {
+                this.connection.startStream();
+            }
         } else {
-            this.emit('error', 'XMPP authentication failure')
+            this.emit('error', 'XMPP authentication failure');
         }
     } else if ((this.state === STATE_BIND) &&
-               stanza.is('iq') &&
-               (stanza.attrs.id === IQID_BIND)) {
+        stanza.is('iq') &&
+        (stanza.attrs.id === IQID_BIND)) {
         if (stanza.attrs.type === 'result') {
-            this.state = STATE_AUTHED
+            this.state = STATE_AUTHED;
             /*jshint camelcase: false */
-            this.did_bind = true
+            this.did_bind = true;
 
-            var bindEl = stanza.getChild('bind', NS_XMPP_BIND)
+            var bindEl = stanza.getChild('bind', NS_XMPP_BIND);
             if (bindEl && bindEl.getChild('jid')) {
-                this.jid = new JID(bindEl.getChild('jid').getText())
+                this.jid = new JID(bindEl.getChild('jid').getText());
             }
 
             /* no stream restart, but next feature */
-            this.useFeatures()
+            this.useFeatures();
         } else {
-            this.emit('error', 'Cannot bind resource')
+            this.emit('error', 'Cannot bind resource');
         }
     } else if ((this.state === STATE_SESSION) &&
-               (true === stanza.is('iq')) &&
-               (stanza.attrs.id === IQID_SESSION)) {
+        (true === stanza.is('iq')) &&
+        (stanza.attrs.id === IQID_SESSION)) {
         if (stanza.attrs.type === 'result') {
-            this.state = STATE_AUTHED
-            this.did_session = true
+            this.state = STATE_AUTHED;
+            this.did_session = true;
 
             /* no stream restart, but next feature (most probably
                we'll go online next) */
-            this.useFeatures()
+            this.useFeatures();
         } else {
-            this.emit('error', 'Cannot bind resource')
+            this.emit('error', 'Cannot bind resource');
         }
     } else if (stanza.name === 'stream:error') {
-        this.emit('error', stanza)
+        this.emit('error', stanza);
     } else if (this.state === STATE_ONLINE) {
-        this.emit('stanza', stanza)
+        this.emit('stanza', stanza);
     }
 }
 
@@ -203,98 +209,113 @@ Client.prototype.onStanza = function(stanza) {
 Client.prototype.useFeatures = function() {
     if ((this.state === STATE_PREAUTH) &&
         this.register) {
-        delete this.register
-        this.doRegister()
+        delete this.register;
+        this.doRegister();
     } else if ((this.state === STATE_PREAUTH) &&
         this.streamFeatures.getChild('mechanisms', NS_XMPP_SASL)) {
-        this.state = STATE_AUTH
+        this.state = STATE_AUTH;
         var offeredMechs = this.streamFeatures.
-            getChild('mechanisms', NS_XMPP_SASL).
-            getChildren('mechanism', NS_XMPP_SASL).
-            map(function(el) { return el.getText() })
+        getChild('mechanisms', NS_XMPP_SASL).
+        getChildren('mechanism', NS_XMPP_SASL).
+        map(function(el) {
+            return el.getText()
+        });
         this.mech = sasl.selectMechanism(
             offeredMechs,
             this.preferredSaslMechanism,
             this.availableSaslMechanisms
-        )
+        );
         if (this.mech) {
-            this.mech.authzid = this.jid.bare().toString()
-            this.mech.authcid = this.jid.user
-            this.mech.password = this.password
+            this.mech.authzid = this.jid.bare().toString();
+            this.mech.authcid = this.jid.user;
+            this.mech.password = this.password;
             /*jshint camelcase: false */
-            this.mech.api_key = this.api_key
-            this.mech.access_token = this.access_token
-            this.mech.oauth2_token = this.oauth2_token
-            this.mech.oauth2_auth = this.oauth2_auth
-            this.mech.realm = this.jid.domain  // anything?
-            if (this.actAs) this.mech.actAs = this.actAs.user
-            this.mech.digest_uri = 'xmpp/' + this.jid.domain
-            var authMsg = encode64(this.mech.auth())
-            var attrs = this.mech.authAttrs()
-            attrs.xmlns = NS_XMPP_SASL
-            attrs.mechanism = this.mech.name
+            this.mech.api_key = this.api_key;
+            this.mech.access_token = this.access_token;
+            this.mech.oauth2_token = this.oauth2_token;
+            this.mech.oauth2_auth = this.oauth2_auth;
+            this.mech.realm = this.jid.domain; // anything?
+            if (this.actAs) {
+                this.mech.actAs = this.actAs.user;
+            }
+            this.mech.digest_uri = 'xmpp/' + this.jid.domain;
+            var authMsg = encode64(this.mech.auth());
+            var attrs = this.mech.authAttrs();
+            attrs.xmlns = NS_XMPP_SASL;
+            attrs.mechanism = this.mech.name;
             this.send(new ltx.Element('auth', attrs)
                 .t(authMsg))
         } else {
-            this.emit('error', 'No usable SASL mechanism')
+            this.emit('error', 'No usable SASL mechanism');
         }
-    } else if ((this.state === STATE_AUTHED) &&
-               !this.did_bind &&
-               this.streamFeatures.getChild('bind', NS_XMPP_BIND)) {
+    } else if ((this.state === STATE_AUTHED) && !this.did_bind &&
+        this.streamFeatures.getChild('bind', NS_XMPP_BIND)) {
         this.state = STATE_BIND
         var bindEl = new ltx.Element(
-            'iq',
-            { type: 'set', id: IQID_BIND }
-        ).c('bind', { xmlns: NS_XMPP_BIND })
-        if (this.jid.resource)
-            bindEl.c('resource').t(this.jid.resource)
-        this.send(bindEl)
-    } else if ((this.state === STATE_AUTHED) &&
-               !this.did_session &&
-               this.streamFeatures.getChild('session', NS_XMPP_SESSION)) {
-        this.state = STATE_SESSION
+            'iq', {
+                type: 'set',
+                id: IQID_BIND
+            }).c('bind', {
+                xmlns: NS_XMPP_BIND
+            });
+        if (this.jid.resource) {
+            bindEl.c('resource').t(this.jid.resource);
+        }
+        this.send(bindEl);
+    } else if ((this.state === STATE_AUTHED) && !this.did_session &&
+        this.streamFeatures.getChild('session', NS_XMPP_SESSION)) {
+        this.state = STATE_SESSION;
         var stanza = new ltx.Element(
-          'iq',
-          { type: 'set', to: this.jid.domain, id: IQID_SESSION  }
-        ).c('session', { xmlns: NS_XMPP_SESSION })
-        this.send(stanza)
+            'iq', {
+                type: 'set',
+                to: this.jid.domain,
+                id: IQID_SESSION
+            }).c('session', {
+                xmlns: NS_XMPP_SESSION
+            });
+        this.send(stanza);
     } else if (this.state === STATE_AUTHED) {
         /* Ok, we're authenticated and all features have been
            processed */
-        this.state = STATE_ONLINE
-        this.emit('online', { jid: this.jid })
+        this.state = STATE_ONLINE;
+        this.emit('online', {
+            jid: this.jid
+        });
     }
 }
 
 Client.prototype.doRegister = function() {
-    var id = 'register' + Math.ceil(Math.random() * 99999)
+    var id = 'register' + Math.ceil(Math.random() * 99999);
     var iq = new ltx.Element(
-        'iq',
-        { type: 'set', id: id, to: this.jid.domain }
-    ).c('query', { xmlns: NS_REGISTER })
-    .c('username').t(this.jid.user).up()
-    .c('password').t(this.password)
-    this.send(iq)
+        'iq', {
+            type: 'set',
+            id: id,
+            to: this.jid.domain
+        }).c('query', {
+            xmlns: NS_REGISTER
+        }).c('username').t(this.jid.user).up()
+        .c('password').t(this.password);
+    this.send(iq);
 
-    var self = this
+    var self = this;
     var onReply = function(reply) {
         if (reply.is('iq') && (reply.attrs.id === id)) {
-            self.removeListener('stanza', onReply)
+            self.removeListener('stanza', onReply);
 
             if (reply.attrs.type === 'result') {
                 /* Registration successful, proceed to auth */
-                self.useFeatures()
+                self.useFeatures();
             } else {
-                self.emit('error', new Error('Registration error'))
+                self.emit('error', new Error('Registration error'));
             }
         }
     }
-    this.on('stanza:preauth', onReply)
+    this.on('stanza:preauth', onReply);
 }
 
-Client.prototype.registerSaslMechanism = function () {
-    var args = arguments.length > 0 ? Array.prototype.slice.call(arguments) : []
-    this.availableSaslMechanisms = this.availableSaslMechanisms.concat(args)
+Client.prototype.registerSaslMechanism = function() {
+    var args = arguments.length > 0 ? Array.prototype.slice.call(arguments) : [];
+    this.availableSaslMechanisms = this.availableSaslMechanisms.concat(args);
 }
 
-exports.Client = Client
+exports.Client = Client;

--- a/lib/xmpp/component.js
+++ b/lib/xmpp/component.js
@@ -1,14 +1,14 @@
 'use strict';
 
-var EventEmitter = require('events').EventEmitter
-  , Connection = require('./connection')
-  , JID = require('./jid').JID
-  , ltx = require('ltx')
-  , util = require('util')
-  , crypto = require('crypto')
-  , SRV = require('./srv')
+var EventEmitter = require('events').EventEmitter,
+    Connection = require('./connection'),
+    JID = require('./jid').JID,
+    ltx = require('ltx'),
+    util = require('util'),
+    crypto = require('crypto'),
+    SRV = require('./srv');
 
-var NS_COMPONENT = 'jabber:component:accept'
+var NS_COMPONENT = 'jabber:component:accept';
 
 /**
  * params:
@@ -19,74 +19,75 @@ var NS_COMPONENT = 'jabber:component:accept'
  *   reconnect: Boolean (optional)
  */
 function Component(params) {
-    EventEmitter.call(this)
-    var self = this
-    var conn = this.connection = new Connection.Connection()
+    EventEmitter.call(this);
+    var self = this;
+    var conn = this.connection = new Connection.Connection();
 
     // proxy the fucntions of the connection instance
     for (var i in conn) {
-        var fn = conn[i]
+        var fn = conn[i];
         // add to component instance if the function does not exist yet
         if ((typeof fn === 'function') && (self[i] == null)) {
             // wrap the function
-            (function(i){
-                self[i] = function(){
+            (function(i) {
+                self[i] = function() {
                     conn[i].apply(conn, arguments)
                 }
-            })(i)
+            })(i);
         }
     }
 
     if (typeof params.jid === 'string') {
-        this.connection.jid = new JID(params.jid)
+        this.connection.jid = new JID(params.jid);
     } else {
-        this.connection.jid = params.jid
+        this.connection.jid = params.jid;
     }
-    this.connection.password = params.password
-    this.connection.xmlns[''] = NS_COMPONENT
-    this.connection.streamTo = this.connection.jid.domain
+    this.connection.password = params.password;
+    this.connection.xmlns[''] = NS_COMPONENT;
+    this.connection.streamTo = this.connection.jid.domain;
 
     this.connection.addListener('streamStart', function(streamAttrs) {
-        self.onStreamStart(streamAttrs)
+        self.onStreamStart(streamAttrs);
     })
     this.connection.addListener('stanza', function(stanza) {
-        self.onStanza(stanza)
+        self.onStanza(stanza);
     })
     this.connection.addListener('error', function(e) {
-        self.emit('error', e)
+        self.emit('error', e);
     })
 
     var connect = function() {
         var attempt = SRV.connect(
-            self.connection.socket,
-            [],
+            self.connection.socket, [],
             params.host,
             params.port
-        )
+        );
         attempt.addListener('connect', function() {
             self.connection.startStream()
-        })
+        });
         attempt.addListener('error', function(e) {
             self.emit('error', e)
-        })
+        });
     }
-    if (params.reconnect) this.connection.reconnect = connect
-    connect()
+    if (params.reconnect) {
+        this.connection.reconnect = connect;
+    }
+    connect();
 }
 
 util.inherits(Component, EventEmitter)
 
 Component.prototype.onStreamStart = function(streamAttrs) {
-    var digest = sha1Hex(streamAttrs.id + this.connection.password)
-    this.connection.send(new ltx.Element('handshake').t(digest))
+    var digest = sha1Hex(streamAttrs.id + this.connection.password);
+    this.connection.send(new ltx.Element('handshake').t(digest));
 }
 
 Component.prototype.onStanza = function(stanza) {
     if (stanza.is('handshake')) {
-        this.emit('online')
-        return
+        this.emit('online');
+        return;
     }
-    this.emit('stanza', stanza)
+    this.emit('stanza', stanza);
 }
 
 // Component.prototype.send = function(stanza) {
@@ -94,9 +95,9 @@ Component.prototype.onStanza = function(stanza) {
 // }
 //
 function sha1Hex(s) {
-    var hash = crypto.createHash('sha1')
-    hash.update(s)
-    return hash.digest('hex')
+    var hash = crypto.createHash('sha1');
+    hash.update(s);
+    return hash.digest('hex');
 }
 
-exports.Component = Component
+exports.Component = Component;

--- a/lib/xmpp/connection.js
+++ b/lib/xmpp/connection.js
@@ -1,83 +1,83 @@
 'use strict';
 
-var net = require('net')
-  , EventEmitter = require('events').EventEmitter
-  , util = require('util')
-  , ltx = require('ltx')
-  , StreamParser = require('./stream_parser')
-  , starttls = require('../starttls')
+var net = require('net'),
+    EventEmitter = require('events').EventEmitter,
+    util = require('util'),
+    ltx = require('ltx'),
+    StreamParser = require('./stream_parser'),
+    starttls = require('../starttls');
 
-var NS_XMPP_TLS = exports.NS_XMPP_TLS = 'urn:ietf:params:xml:ns:xmpp-tls'
-var NS_STREAM = exports.NS_STREAM = 'http://etherx.jabber.org/streams'
-var NS_XMPP_STREAMS = 'urn:ietf:params:xml:ns:xmpp-streams'
+var NS_XMPP_TLS = exports.NS_XMPP_TLS = 'urn:ietf:params:xml:ns:xmpp-tls';
+var NS_STREAM = exports.NS_STREAM = 'http://etherx.jabber.org/streams';
+var NS_XMPP_STREAMS = 'urn:ietf:params:xml:ns:xmpp-streams';
 
 /**
  Base class for connection-based streams (TCP).
  The socket parameter is optional for incoming connections.
 */
-var MAX_RECONNECT_DELAY = 30 * 1000
+var MAX_RECONNECT_DELAY = 30 * 1000;
 
 function Connection(opts) {
-    EventEmitter.call(this)
+    EventEmitter.call(this);
 
-    this.streamAttrs = (opts && opts.streamAttrs) || {}
-    this.xmlns = (opts && opts.xmlns) || {}
-    this.xmlns.stream = NS_STREAM
+    this.streamAttrs = (opts && opts.streamAttrs) || {};
+    this.xmlns = (opts && opts.xmlns) || {};
+    this.xmlns.stream = NS_STREAM;
 
-    this.socket = (opts && opts.socket) || new net.Socket()
+    this.socket = (opts && opts.socket) || new net.Socket();
 
-    this.rejectUnauthorized = (opts && opts.rejectUnauthorized) ? true : false
-    this.requestCert = (opts && opts.requestCert) ? true : false
+    this.rejectUnauthorized = (opts && opts.rejectUnauthorized) ? true : false;
+    this.requestCert = (opts && opts.requestCert) ? true : false;
 
-    this.reconnectDelay = 0
+    this.reconnectDelay = 0;
 
     this.setupStream()
     if (opts && opts.socket) {
-        this.startParser()
+        this.startParser();
     } else {
-        var that = this
+        var that = this;
         this.socket.on('connect', function() {
-            that.startParser()
-            that.emit('connect')
+            that.startParser();
+            that.emit('connect');
         })
     }
-    this.mixins = []
+    this.mixins = [];
 }
 
-util.inherits(Connection, EventEmitter)
-exports.Connection = Connection
+util.inherits(Connection, EventEmitter);
+exports.Connection = Connection;
 
 // Defaults
-Connection.prototype.allowTLS = true
+Connection.prototype.allowTLS = true;
 
 /**
  Used by both the constructor and by reinitialization in setSecure().
 */
 Connection.prototype.setupStream = function() {
-    var self = this
+    var self = this;
 
     this.socket.addListener('data', function(data) {
-        self.onData(data)
+        self.onData(data);
     })
     this.socket.addListener('end', function() {
-        self.onEnd()
+        self.onEnd();
     })
     this.socket.addListener('error', function() {
         /* unhandled errors may throw up in node, preventing a reconnect */
-        self.onEnd()
+        self.onEnd();
     })
     this.socket.addListener('close', function() {
-        self.onClose()
+        self.onClose();
     })
     var proxyEvent = function(event) {
         self.socket.addListener(event, function() {
-            var args = Array.prototype.slice.call(arguments)
-            args.unshift(event)
-            self.emit.apply(self, args)
+            var args = Array.prototype.slice.call(arguments);
+            args.unshift(event);
+            self.emit.apply(self, args);
         })
     }
-    proxyEvent('data') // let them sniff unparsed XML
-    proxyEvent('drain')
+    proxyEvent('data'); // let them sniff unparsed XML
+    proxyEvent('drain');
 
     /**
      * This is optimized for continuous TCP streams. If your "socket"
@@ -89,7 +89,7 @@ Connection.prototype.setupStream = function() {
         this.socket.serializeStanza = function(el, cb) {
             // Continuously write out
             el.write(function(s) {
-                cb(s)
+                cb(s);
             })
         }
     }
@@ -97,11 +97,15 @@ Connection.prototype.setupStream = function() {
 
 
 Connection.prototype.pause = function() {
-    if (this.socket.pause) this.socket.pause()
+    if (this.socket.pause) {
+        this.socket.pause();
+    }
 }
 
 Connection.prototype.resume = function() {
-    if (this.socket.resume) this.socket.resume()
+    if (this.socket.resume) {
+        this.socket.resume()
+    }
 }
 
 /** Climbs the stanza up if a child was passed,
@@ -110,53 +114,53 @@ Connection.prototype.resume = function() {
     Returns whether the socket flushed data.
 */
 Connection.prototype.send = function(stanza) {
-    var self = this
-    var flushed = true
+    var self = this;
+    var flushed = true;
     if (!this.socket) {
         return // Doh!
     }
     if (!this.socket.writable) {
-        this.socket.end()
-        return
+        this.socket.end();
+        return;
     }
 
     if (stanza.root) {
-        var el = this.rmXmlns(stanza.root())
+        var el = this.rmXmlns(stanza.root());
         this.socket.serializeStanza(el, function(s) {
-            flushed = self.socket.write(s)
+            flushed = self.socket.write(s);
         })
     } else {
-        flushed = this.socket.write(stanza)
+        flushed = this.socket.write(stanza);
     }
-    return flushed
+    return flushed;
 }
 
 Connection.prototype.startParser = function() {
-    var self = this
-    this.parser = new StreamParser.StreamParser(this.maxStanzaSize)
+    var self = this;
+    this.parser = new StreamParser.StreamParser(this.maxStanzaSize);
 
     this.parser.addListener('streamStart', function(attrs) {
         /* We need those xmlns often, store them extra */
-        self.streamNsAttrs = {}
+        self.streamNsAttrs = {};
         for (var k in attrs) {
             if (k === 'xmlns' || (k.substr(0, 6) === 'xmlns:'))
-                self.streamNsAttrs[k] = attrs[k]
+                self.streamNsAttrs[k] = attrs[k];
         }
 
         /* Notify in case we don't wait for <stream:features/>
            (Component or non-1.0 streams)
          */
-        self.emit('streamStart', attrs)
+        self.emit('streamStart', attrs);
     })
     this.parser.addListener('stanza', function(stanza) {
-        self.onStanza(self.addStreamNs(stanza))
+        self.onStanza(self.addStreamNs(stanza));
     })
     this.parser.addListener('error', function(e) {
-        self.error(e.condition || 'internal-server-error', e.message)
+        self.error(e.condition || 'internal-server-error', e.message);
     })
     this.parser.addListener('end', function() {
-        self.stopParser()
-        self.end()
+        self.stopParser();
+        self.end();
     })
 }
 
@@ -164,82 +168,86 @@ Connection.prototype.stopParser = function() {
     /* No more events, please (may happen however) */
     if (this.parser) {
         /* Get GC'ed */
-        delete this.parser
+        delete this.parser;
     }
 }
 
 Connection.prototype.startStream = function() {
     /* reset reconnect delay */
-    this.reconnectDelay = 0
+    this.reconnectDelay = 0;
 
-    var attrs = {}
+    var attrs = {};
     for (var k in this.xmlns) {
         if (this.xmlns.hasOwnProperty(k)) {
-            if (!k)
-                attrs.xmlns = this.xmlns[k]
-            else
-                attrs['xmlns:' + k] = this.xmlns[k]
+            if (!k) {
+                attrs.xmlns = this.xmlns[k];
+            } else {
+                attrs['xmlns:' + k] = this.xmlns[k];
+            }
         }
     }
     for (k in this.streamAttrs) {
-        if (this.streamAttrs.hasOwnProperty(k))
-            attrs[k] = this.streamAttrs[k]
+        if (this.streamAttrs.hasOwnProperty(k)) {
+            attrs[k] = this.streamAttrs[k];
+        }
     }
 
     if (this.streamTo) { // in case of a component connecting
-        attrs.to = this.streamTo
+        attrs.to = this.streamTo;
     }
 
-    var el = new ltx.Element('stream:stream', attrs)
+    var el = new ltx.Element('stream:stream', attrs);
     // make it non-empty to cut the closing tag
-    el.t(' ')
-    var s = el.toString()
-    this.send(s.substr(0, s.indexOf(' </stream:stream>')))
+    el.t(' ');
+    var s = el.toString();
+    this.send(s.substr(0, s.indexOf(' </stream:stream>')));
 
-    this.streamOpened = true
+    this.streamOpened = true;
 }
 
 Connection.prototype.onData = function(data) {
-    if (this.parser)
-        this.parser.write(data)
+    if (this.parser) {
+        this.parser.write(data);
+    }
 }
 
 Connection.prototype.setSecure = function(credentials, isServer) {
-    var self = this
+    var self = this;
 
     // Remove old event listeners
-    this.socket.removeAllListeners('data')
+    this.socket.removeAllListeners('data');
     // retain socket 'end' listeners because ssl layer doesn't support it
-    this.socket.removeAllListeners('drain')
-    this.socket.removeAllListeners('close')
+    this.socket.removeAllListeners('drain');
+    this.socket.removeAllListeners('close');
     // remove idle_timeout
-    if (this.socket.clearTimer)
-        this.socket.clearTimer()
+    if (this.socket.clearTimer) {
+        this.socket.clearTimer();
+    }
 
-    this.stopParser()
+    this.stopParser();
     var ct = starttls(this.socket, {
         rejectUnauthorized: this.rejectUnauthorized,
         credentials: credentials || this.credentials,
         requestCert: this.requestCert,
-        isServer: !!isServer
+        isServer: !! isServer
     }, function() {
-        self.isSecure = true
-        self.startParser()
+        self.isSecure = true;
+        self.startParser();
         if (!isServer) {
             // Clients start <stream:stream>, servers reply
-            self.startStream()
+            self.startStream();
         }
     })
     ct.on('close', function() {
-        self.onClose()
-        self.isSecure = false
+        self.onClose();
+        self.isSecure = false;
     })
 
     // The socket is now the cleartext stream
-    this.socket = ct
+    this.socket = ct;
 
     // Attach new listeners on the cleartext stream
-    this.setupStream()
+    this.setupStream();
 }
 
 /**
@@ -249,19 +257,20 @@ Connection.prototype.setSecure = function(credentials, isServer) {
 Connection.prototype.onStanza = function(stanza) {
     if (stanza.is('error', NS_STREAM)) {
         /* TODO: extract error text */
-        this.emit('error', stanza)
+        this.emit('error', stanza);
     } else if (stanza.is('features', NS_STREAM) &&
-        this.allowTLS &&
-        !this.isSecure &&
+        this.allowTLS && !this.isSecure &&
         stanza.getChild('starttls', NS_XMPP_TLS)) {
         /* Signal willingness to perform TLS handshake */
-        this.send(new ltx.Element('starttls', { xmlns: NS_XMPP_TLS }))
+        this.send(new ltx.Element('starttls', {
+            xmlns: NS_XMPP_TLS
+        }));
     } else if (this.allowTLS &&
         stanza.is('proceed', NS_XMPP_TLS)) {
         /* Server is waiting for TLS handshake */
-        this.setSecure()
+        this.setSecure();
     } else {
-        this.emit('stanza', stanza)
+        this.emit('stanza', stanza);
     }
 }
 
@@ -273,13 +282,11 @@ Connection.prototype.onStanza = function(stanza) {
  */
 Connection.prototype.addStreamNs = function(stanza) {
     for (var attr in this.streamNsAttrs) {
-        if (!stanza.attrs[attr] &&
-            !((attr === 'xmlns') && (this.streamNsAttrs[attr] === this.xmlns['']))
-           ) {
-            stanza.attrs[attr] = this.streamNsAttrs[attr]
+        if (!stanza.attrs[attr] && !((attr === 'xmlns') && (this.streamNsAttrs[attr] === this.xmlns['']))) {
+            stanza.attrs[attr] = this.streamNsAttrs[attr];
         }
     }
-    return stanza
+    return stanza;
 }
 
 /**
@@ -290,9 +297,9 @@ Connection.prototype.rmXmlns = function(stanza) {
     for (var prefix in this.xmlns) {
         var attr = prefix ? 'xmlns:' + prefix : 'xmlns'
         if (stanza.attrs[attr] === this.xmlns[prefix])
-            delete stanza.attrs[attr]
+            delete stanza.attrs[attr];
     }
-    return stanza
+    return stanza;
 }
 
 /**
@@ -300,9 +307,11 @@ Connection.prototype.rmXmlns = function(stanza) {
  * 'data' events. Alternatively, used for 'error' event.
  */
 Connection.prototype.onEnd = function() {
-    this.stopParser()
-    if (this.socket) this.socket.end()
-    this.emit('end')
+    this.stopParser();
+    if (this.socket) {
+        this.socket.end();
+    }
+    this.emit('end');
 }
 
 /**
@@ -311,11 +320,11 @@ Connection.prototype.onEnd = function() {
 Connection.prototype.end = function() {
     if (this.socket && this.socket.writable) {
         if (this.streamOpened) {
-            this.socket.write('</stream:stream>')
-            delete this.streamOpened
+            this.socket.write('</stream:stream>');
+            delete this.streamOpened;
             /* wait for being called again upon 'end' from other side */
         } else {
-            this.socket.end()
+            this.socket.end();
         }
     }
 }
@@ -323,23 +332,24 @@ Connection.prototype.end = function() {
 Connection.prototype.onClose = function() {
     if (!this.socket) {
         /* A reconnect may have already been scheduled */
-        return
+        return;
     }
 
-    delete this.socket
+    delete this.socket;
     if (this.reconnect) {
-        var self = this
+        var self = this;
         setTimeout(function() {
             self.socket = new net.Stream()
             self.setupStream()
             self.reconnect()
-        }, this.reconnectDelay)
-        console.log('Reconnect in', this.reconnectDelay)
-        this.reconnectDelay += Math.ceil(Math.random() * 2000)
-        if (this.reconnectDelay > MAX_RECONNECT_DELAY)
+        }, this.reconnectDelay);
+        console.log('Reconnect in', this.reconnectDelay);
+        this.reconnectDelay += Math.ceil(Math.random() * 2000);
+        if (this.reconnectDelay > MAX_RECONNECT_DELAY) {
             this.reconnectDelay = MAX_RECONNECT_DELAY
+        }
     } else {
-        this.emit('close')
+        this.emit('close');
     }
 }
 
@@ -351,22 +361,28 @@ Connection.prototype.onClose = function() {
  * @param {String} text Optional error message
  */
 Connection.prototype.error = function(condition, message) {
-    this.emit('error', new Error(message))
+    this.emit('error', new Error(message));
 
-    if (!this.socket || !this.socket.writable) return
-
-    /* RFC 3920, 4.7.1 stream-level errors rules */
-    if (!this.streamOpened) this.startStream()
-
-    var e = new ltx.Element('stream:error')
-    e.c(condition, { xmlns: NS_XMPP_STREAMS })
-    if (message) {
-        e.c(
-            'text',
-            { xmlns: NS_XMPP_STREAMS, 'xml:lang': 'en' }
-        ).t(message)
+    if (!this.socket || !this.socket.writable) {
+        return;
     }
 
-    this.send(e)
-    this.end()
+    /* RFC 3920, 4.7.1 stream-level errors rules */
+    if (!this.streamOpened) this.startStream();
+
+    var e = new ltx.Element('stream:error');
+    e.c(condition, {
+        xmlns: NS_XMPP_STREAMS
+    });
+    if (message) {
+        e.c(
+            'text', {
+                xmlns: NS_XMPP_STREAMS,
+                'xml:lang': 'en'
+            }
+        ).t(message);
+    }
+
+    this.send(e);
+    this.end();
 }

--- a/lib/xmpp/jid.js
+++ b/lib/xmpp/jid.js
@@ -1,19 +1,25 @@
+'use strict';
+
 try {
     var StringPrep = require('node-stringprep').StringPrep;
     var toUnicode = require('node-stringprep').toUnicode;
     var c = function(n) {
-    var p = new StringPrep(n);
-    return function(s) {
-        return p.prepare(s);
-    };
+        var p = new StringPrep(n);
+        return function(s) {
+            return p.prepare(s);
+        };
     };
     var nameprep = c('nameprep');
     var nodeprep = c('nodeprep');
     var resourceprep = c('resourceprep');
-} catch(ex) {
+} catch (ex) {
     console.warn("Cannot load StringPrep-0.1.0 bindings. You may need to `npm install node-stringprep'");
-    var identity = function(a) { return a; };
-    var toLower = function(a) { return a.toLowerCase(); };
+    var identity = function(a) {
+        return a;
+    };
+    var toLower = function(a) {
+        return a.toLowerCase();
+    };
     var toUnicode = identity;
     var nameprep = toLower;
     var nodeprep = toLower;
@@ -66,9 +72,9 @@ JID.prototype.bare = function() {
  * Comparison function
  **/
 JID.prototype.equals = function(other) {
-    return this.user == other.user &&
-        this.domain == other.domain &&
-        this.resource == other.resource;
+    return this.user === other.user &&
+        this.domain === other.domain &&
+        this.resource === other.resource;
 };
 
 /**
@@ -82,16 +88,14 @@ JID.prototype.setUser = function(user) {
  */
 JID.prototype.setDomain = function(domain) {
     this.domain = domain &&
-        nameprep(domain.split(".").
-                 map(toUnicode).
-                 join("."));
+        nameprep(domain.split('.').map(toUnicode).join('.'));
 };
 JID.prototype.setResource = function(resource) {
     this.resource = resource && resourceprep(resource);
 };
 
-if (typeof exports !== "undefined" && exports !== null) {
-  exports.JID = JID;
-} else if (typeof window !== "undefined" && window !== null) {
-  window.JID = JID;
+if (typeof exports !== 'undefined' && exports !== null) {
+    exports.JID = JID;
+} else if (typeof window !== 'undefined' && window !== null) {
+    window.JID = JID;
 }

--- a/lib/xmpp/router.js
+++ b/lib/xmpp/router.js
@@ -1,28 +1,31 @@
-var net = require('net');
-var Server = require('./server');
-var JID = require('./jid');
-var ltx = require('ltx');
-var StreamShaper = require('./../stream_shaper');
-var IdleTimeout = require('./../idle_timeout');
-var EventEmitter = require('events').EventEmitter;
-var util = require('util');
+'use strict';
+
+var net = require('net'),
+    Server = require('./server'),
+    JID = require('./jid'),
+    ltx = require('ltx'),
+    StreamShaper = require('./../stream_shaper'),
+    IdleTimeout = require('./../idle_timeout'),
+    EventEmitter = require('events').EventEmitter,
+    util = require('util');
 
 try {
     var StringPrep = require('node-stringprep').StringPrep;
     var c = function(n) {
-    var p = new StringPrep(n);
-    return function(s) {
-        return p.prepare(s);
-    };
+        var p = new StringPrep(n);
+        return function(s) {
+            return p.prepare(s);
+        };
     };
     var nameprep = c('nameprep');
 } catch (ex) {
-    var nameprep = function(a) { return a; };
+    var nameprep = function(a) {
+        return a;
+    };
 }
 
 var NS_XMPP_SASL = 'urn:ietf:params:xml:ns:xmpp-sasl';
 var NS_XMPP_STANZAS = 'urn:ietf:params:xml:ns:xmpp-stanzas';
-
 
 /**
  * Represents a domain we host with connections to federated servers
@@ -38,8 +41,9 @@ function DomainContext(router, domain) {
  * Buffers until stream has been verified via Dialback
  */
 DomainContext.prototype.send = function(stanza) {
-    if (stanza.root)
+    if (stanza.root) {
         stanza = stanza.root();
+    }
 
     // no destination? return to ourself
     if (!stanza.attrs.to) {
@@ -50,8 +54,12 @@ DomainContext.prototype.send = function(stanza) {
         stanza.attrs.to = stanza.attrs.from;
         delete stanza.attrs.from;
         stanza.attrs.type = 'error';
-        stanza.c('error', { type: 'modify' }).
-            c('jid-malformed', { xmlns: NS_XMPP_STANZAS });
+        stanza.c('error', {
+            type: 'modify'
+        }).
+        c('jid-malformed', {
+            xmlns: NS_XMPP_STANZAS
+        });
         this.receive(stanza);
 
         return;
@@ -60,9 +68,9 @@ DomainContext.prototype.send = function(stanza) {
     var destDomain = new JID.JID(stanza.attrs.to).domain;
     var outStream = this.getOutStream(destDomain);
 
-    if (outStream.isAuthed)
+    if (outStream.isAuthed) {
         outStream.send(stanza);
-    else {
+    } else {
         // TODO: queues per domain in domaincontext
         outStream.queue = outStream.queue || [];
         outStream.queue.push(stanza);
@@ -76,18 +84,19 @@ DomainContext.prototype.send = function(stanza) {
  * returns the stream
  */
 DomainContext.prototype.sendRaw = function(stanza, destDomain) {
-    if (stanza.root)
+    if (stanza.root) {
         stanza = stanza.root();
-
+    }
     var outStream = this.getOutStream(destDomain);
     var send = function() {
         outStream.send(stanza);
     };
 
-    if (outStream.isConnected)
+    if (outStream.isConnected) {
         send();
-    else
+    } else {
         outStream.addListener('online', send);
+    }
 
     return outStream;
 };
@@ -118,18 +127,22 @@ DomainContext.prototype.getOutStream = function(destDomain) {
             // purge queue
             if (outStream.queue) {
                 outStream.queue.forEach(function(stanza) {
-                                            // do not provoke ping-pong effects
-                                            if (stanza.attrs.type === 'error')
-                                                return;
+                    // do not provoke ping-pong effects
+                    if (stanza.attrs.type === 'error')
+                        return;
 
-                                            var dest = stanza.attrs.to;
-                                            stanza.attrs.to = stanza.attrs.from;
-                                            stanza.attrs.from = dest;
-                                            stanza.attrs.type = 'error';
-                                            stanza.c('error', { type: 'cancel' }).
-                                                c('remote-server-not-found', { xmlns: NS_XMPP_STANZAS });
-                                            self.receive(stanza);
-                                        });
+                    var dest = stanza.attrs.to;
+                    stanza.attrs.to = stanza.attrs.from;
+                    stanza.attrs.from = dest;
+                    stanza.attrs.type = 'error';
+                    stanza.c('error', {
+                        type: 'cancel'
+                    }).
+                    c('remote-server-not-found', {
+                        xmlns: NS_XMPP_STANZAS
+                    });
+                    self.receive(stanza);
+                });
             }
             delete outStream.queue;
 
@@ -139,18 +152,17 @@ DomainContext.prototype.getOutStream = function(destDomain) {
         outStream.addListener('close', closeCb);
         outStream.addListener('error', closeCb);
 
-        var onAuth =  function(method) {
+        var onAuth = function(method) {
             outStream.isConnected = true;
-            switch(method) {
+            switch (method) {
             case 'dialback':
                 self.startDialback(destDomain, outStream);
                 break;
-
             case 'external':
-                outStream.send(new ltx.Element('auth', { xmlns: NS_XMPP_SASL,
-                                                         mechanism: 'EXTERNAL' }).
-                               t(new Buffer(self.domain).toString('base64'))
-                              );
+                outStream.send(new ltx.Element('auth', {
+                    xmlns: NS_XMPP_SASL,
+                    mechanism: 'EXTERNAL'
+                }).t(new Buffer(self.domain).toString('base64')));
                 var onStanza;
                 onStanza = function(stanza) {
                     if (stanza.is('success', NS_XMPP_SASL)) {
@@ -169,8 +181,7 @@ DomainContext.prototype.getOutStream = function(destDomain) {
                 break;
 
             default:
-                outStream.error('undefined-condition',
-                                'Cannot authenticate via ' + method);
+                outStream.error('undefined-condition', 'Cannot authenticate via ' + method);
             }
             outStream.removeListener('auth', onAuth);
         };
@@ -207,8 +218,9 @@ DomainContext.prototype.addInStream = function(srcDomain, stream) {
     stream.isConnected = true;
     stream.isAuthed = true;
     var closeCb = function() {
-        if (self.s2sIn[srcDomain] == stream)
+        if (self.s2sIn[srcDomain] === stream) {
             delete self.s2sIn[srcDomain];
+        }
     };
     stream.addListener('close', closeCb);
     stream.addListener('error', closeCb);
@@ -226,12 +238,12 @@ DomainContext.prototype.setupStream = function(domain, stream) {
         if (stanza.name !== 'message' &&
             stanza.name !== 'presence' &&
             stanza.name !== 'iq')
-            // no normal stanza
+        // no normal stanza
             return;
 
 
         if (!(typeof stanza.attrs.from === 'string' &&
-              typeof stanza.attrs.to === 'string')) {
+            typeof stanza.attrs.to === 'string')) {
             stream.error('improper-addressing');
             return;
         }
@@ -262,9 +274,9 @@ DomainContext.prototype.startDialback = function(destDomain, outStream) {
 
     var self = this;
     var onResult = function(from, to, isValid) {
-        if (from != destDomain ||
-            to != self.domain)
-            // not for us
+        if (from !== destDomain ||
+            to !== self.domain)
+        // not for us
             return;
 
         outStream.removeListener('dialbackResult', onResult);
@@ -289,7 +301,7 @@ DomainContext.prototype.verifyDialback = function(domain, id, key, cb) {
 
         if (outStream.isConnected) {
             var isValid = outStream.streamAttrs.id === id &&
-                              outStream.dbKey === key;
+                outStream.dbKey === key;
             cb(isValid);
         } else {
             // Not online, wait for outStream.streamAttrs
@@ -297,12 +309,12 @@ DomainContext.prototype.verifyDialback = function(domain, id, key, cb) {
             // our slow connection hasn't received their stream
             // header)
             outStream.addListener('online', function() {
-                                      // recurse
-                                      self.verifyDialback(domain, id, key, cb);
-                                  });
+                // recurse
+                self.verifyDialback(domain, id, key, cb);
+            });
             outStream.addListener('close', function() {
-                                      cb(false);
-                                  });
+                cb(false);
+            });
         }
     } else
         cb(false);
@@ -311,17 +323,17 @@ DomainContext.prototype.verifyDialback = function(domain, id, key, cb) {
 DomainContext.prototype.verifyIncoming = function(fromDomain, inStream, dbKey) {
     var self = this;
     var outStream = this.sendRaw(Server.dialbackVerify(this.domain, fromDomain,
-                                                       inStream.streamId, dbKey),
-                                 fromDomain);
+            inStream.streamId, dbKey),
+        fromDomain);
 
     // these are needed before for removeListener()
     var onVerified = function(from, to, id, isValid) {
-    from = nameprep(from);
-    to = nameprep(to);
+        from = nameprep(from);
+        to = nameprep(to);
         if (from !== fromDomain ||
             to !== self.domain ||
-            id != inStream.streamId)
-            // not for us
+            id !== inStream.streamId)
+        // not for us
             return;
 
         // tell them about it
@@ -370,7 +382,7 @@ DomainContext.prototype.receive = function(stanza) {
 
 DomainContext.prototype.end = function() {
     var shutdown = function(conns) {
-        for(var domain in conns)
+        for (var domain in conns)
             if (conns.hasOwnProperty(domain))
                 conns[domain].end();
     };
@@ -399,11 +411,11 @@ util.inherits(Router, EventEmitter);
 exports.Router = Router;
 
 // Defaults
-Router.prototype.rateLimit = 100;  // 100 KB/s, it's S2S after all
-Router.prototype.maxStanzaSize = 65536;  // 64 KB, by convention
-Router.prototype.keepAlive = 30 * 1000;  // 30s
-Router.prototype.streamTimeout = 5 * 60 * 1000;  // 5min
-Router.prototype.credentials = {};  // TLS credentials per domain
+Router.prototype.rateLimit = 100; // 100 KB/s, it's S2S after all
+Router.prototype.maxStanzaSize = 65536; // 64 KB, by convention
+Router.prototype.keepAlive = 30 * 1000; // 30s
+Router.prototype.streamTimeout = 5 * 60 * 1000; // 5min
+Router.prototype.credentials = {}; // TLS credentials per domain
 
 // little helper, because dealing with crypto & fs gets unwieldy
 Router.prototype.loadCredentials = function(domain, keyPath, certPath) {
@@ -413,7 +425,10 @@ Router.prototype.loadCredentials = function(domain, keyPath, certPath) {
     var key = fs.readFileSync(keyPath, 'ascii');
     var cert = fs.readFileSync(certPath, 'ascii');
 
-    var creds = crypto.createCredentials({ key: key, cert: cert });
+    var creds = crypto.createCredentials({
+        key: key,
+        cert: cert
+    });
 
     this.credentials[domain] = creds;
 };
@@ -426,20 +441,20 @@ Router.prototype.acceptConnection = function(socket) {
 
     // Unhandled 'error' events will trigger exceptions, don't let
     // that happen:
-    socket.addListener('error', function() { });
-    inStream.addListener('error', function() { });
+    socket.addListener('error', function() {});
+    inStream.addListener('error', function() {});
 
     // incoming server wants to verify an outgoing connection of ours
     inStream.addListener('dialbackVerify', function(from, to, id, key) {
         from = nameprep(from);
-    to = nameprep(to);
+        to = nameprep(to);
         if (self.hasContext(to)) {
             self.getContext(to).verifyDialback(from, id, key, function(isValid) {
                 // look if this was a connection of ours
                 inStream.send(Server.dialbackVerified(to, from, id, isValid));
             });
         } else
-            // we don't host the 'to' domain
+        // we don't host the 'to' domain
             inStream.send(Server.dialbackVerified(to, from, id, false));
     });
     // incoming connection wants to get verified
@@ -507,20 +522,21 @@ Router.prototype.hasContext = function(domain) {
 };
 
 Router.prototype.getContext = function(domain) {
-    if (this.ctxs.hasOwnProperty(domain))
+    if (this.ctxs.hasOwnProperty(domain)) {
         return this.ctxs[domain];
-    else
-        return (this.ctxs[domain] = new DomainContext(this, domain));
+    } else {
+        this.ctxs[domain] = new DomainContext(this, domain)
+        return this.ctxs[domain];
+    }
 };
-
 
 /**
  * TODO: According to XEP-0185 we should hash from, to & streamId
  */
 function generateKey() {
     var r = new Buffer(16);
-    for(var i = 0; i < r.length; i++) {
-        r[i] = 48 + Math.floor(Math.random() * 10);  // '0'..'9'
+    for (var i = 0; i < r.length; i++) {
+        r[i] = 48 + Math.floor(Math.random() * 10); // '0'..'9'
     }
     return r.toString();
 }

--- a/lib/xmpp/sasl.js
+++ b/lib/xmpp/sasl.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var Anonymous = require('../authentication/anonymous')
-  , Plain = require('../authentication/plain')
-  , DigestMD5 = require('../authentication/digestmd5')
-  , XOAuth2 = require('../authentication/xoauth2')
-  , XFacebookPlatform = require('../authentication/xfacebook')
-  , External = require('../authentication/external')
+var Anonymous = require('../authentication/anonymous'),
+    Plain = require('../authentication/plain'),
+    DigestMD5 = require('../authentication/digestmd5'),
+    XOAuth2 = require('../authentication/xoauth2'),
+    XFacebookPlatform = require('../authentication/xfacebook'),
+    External = require('../authentication/external');
 
 /**
  * Available methods for client-side authentication (Client)
@@ -14,31 +14,32 @@ var Anonymous = require('../authentication/anonymous')
  * @param  Array availableMech available methods on client
  */
 function selectMechanism(offeredMechs, preferredMech, availableMech) {
-    var mechClasses = []
-    var byName = {}
-    var Mech
+    var mechClasses = [];
+    var byName = {};
+    var Mech;
     if (Array.isArray(availableMech)) {
-        mechClasses = mechClasses.concat(availableMech)
+        mechClasses = mechClasses.concat(availableMech);
     }
     mechClasses.forEach(function(mechClass) {
-        byName[mechClass.prototype.name] = mechClass
+        byName[mechClass.prototype.name] = mechClass;
     })
     /* Any preferred? */
     if (byName[preferredMech] &&
         (offeredMechs.indexOf(preferredMech) >= 0)) {
-        Mech = byName[preferredMech]
+        Mech = byName[preferredMech];
     }
     /* By priority */
     mechClasses.forEach(function(mechClass) {
         if (!Mech &&
-            (offeredMechs.indexOf(mechClass.prototype.name) >= 0))
-            Mech = mechClass
+            (offeredMechs.indexOf(mechClass.prototype.name) >= 0)) {
+            Mech = mechClass;
+        }
     })
 
-    return Mech ? new Mech() : null
+    return Mech ? new Mech() : null;
 }
 
-exports.selectMechanism = selectMechanism
+exports.selectMechanism = selectMechanism;
 
 
 /**
@@ -49,27 +50,30 @@ exports.selectMechanism = selectMechanism
 function detectMechanisms(options) {
     var mechClasses = [
         XOAuth2, XFacebookPlatform, External, DigestMD5, Plain, Anonymous
-    ]
+    ];
 
-    var detect = []
+    var detect = [];
     mechClasses.forEach(function(mechClass) {
-        var match = mechClass.prototype.match
-        if (match(options)) detect.push(mechClass)
+        var match = mechClass.prototype.match;
+        if (match(options)) {
+            detect.push(mechClass);
+        }
     })
-    return detect
+    return detect;
 }
 
-exports.detectMechanisms = detectMechanisms
+exports.detectMechanisms = detectMechanisms;
 
 /**
  * What's available for server-side authentication (C2S)
  */
 function availableMechanisms(availableMech) {
     // default methods
-    var mechanisms = [new Plain()]
-    if (availableMech)
+    var mechanisms = [new Plain()];
+    if (availableMech) {
         mechanisms = mechanisms.concat(availableMech)
-    return mechanisms
+    }
+    return mechanisms;
 }
 
-exports.availableMechanisms = availableMechanisms
+exports.availableMechanisms = availableMechanisms;

--- a/lib/xmpp/server.js
+++ b/lib/xmpp/server.js
@@ -1,8 +1,10 @@
-var dns = require('dns');
-var Connection = require('./connection');
-var ltx = require('ltx');
-var util = require('util');
-var SRV = require('./srv');
+'use strict';
+
+var dns = require('dns'),
+    Connection = require('./connection'),
+    ltx = require('ltx'),
+    util = require('util'),
+    SRV = require('./srv');
 
 var NS_SERVER = 'jabber:server';
 var NS_DIALBACK = 'jabber:server:dialback';
@@ -31,14 +33,14 @@ function Server(socket) {
                 stanza.attrs.type) {
 
                 self.emit('dialbackResult',
-                          stanza.attrs.from, stanza.attrs.to,
-                          stanza.attrs.type == 'valid');
+                    stanza.attrs.from, stanza.attrs.to,
+                    stanza.attrs.type === 'valid');
 
             } else if (stanza.attrs.from && stanza.attrs.to) {
 
                 self.emit('dialbackKey',
-                          stanza.attrs.from, stanza.attrs.to,
-                          key);
+                    stanza.attrs.from, stanza.attrs.to,
+                    key);
 
             }
         } else if (stanza.is('verify', NS_DIALBACK)) {
@@ -46,15 +48,15 @@ function Server(socket) {
                 stanza.attrs.id && stanza.attrs.type) {
 
                 self.emit('dialbackVerified',
-                          stanza.attrs.from, stanza.attrs.to,
-                          stanza.attrs.id, stanza.attrs.type == 'valid');
+                    stanza.attrs.from, stanza.attrs.to,
+                    stanza.attrs.id, stanza.attrs.type === 'valid');
 
             } else if (stanza.attrs.from && stanza.attrs.to &&
-                       stanza.attrs.id) {
+                stanza.attrs.id) {
 
                 self.emit('dialbackVerify',
-                          stanza.attrs.from, stanza.attrs.to,
-                          stanza.attrs.id, key);
+                    stanza.attrs.from, stanza.attrs.to,
+                    stanza.attrs.id, key);
             }
         } else
             self.emit('stanza', stanza);
@@ -63,26 +65,34 @@ function Server(socket) {
 util.inherits(Server, Connection.Connection);
 
 exports.dialbackKey = function(from, to, key) {
-    return new ltx.Element('db:result', { to: to,
-                                          from: from }).
-        t(key);
+    return new ltx.Element('db:result', {
+        to: to,
+        from: from
+    }).
+    t(key);
 };
 exports.dialbackVerify = function(from, to, id, key) {
-    return new ltx.Element('db:verify', { to: to,
-                                          from: from,
-                                          id: id }).
-        t(key);
+    return new ltx.Element('db:verify', {
+        to: to,
+        from: from,
+        id: id
+    }).
+    t(key);
 };
 exports.dialbackVerified = function(from, to, id, isValid) {
-    return new ltx.Element('db:verify', { to: to,
-                                          from: from,
-                                          id: id,
-                                          type: isValid ? 'valid' : 'invalid' });
+    return new ltx.Element('db:verify', {
+        to: to,
+        from: from,
+        id: id,
+        type: isValid ? 'valid' : 'invalid'
+    });
 };
 exports.dialbackResult = function(from, to, isValid) {
-    return new ltx.Element('db:result', { to: to,
-                                          from: from,
-                                          type: isValid ? 'valid' : 'invalid' });
+    return new ltx.Element('db:result', {
+        to: to,
+        from: from,
+        type: isValid ? 'valid' : 'invalid'
+    });
 };
 
 exports.IncomingServer = function(stream, credentials) {
@@ -96,7 +106,7 @@ exports.IncomingServer = function(stream, credentials) {
         if (streamAttrs.to &&
             credentials &&
             credentials.hasOwnProperty(streamAttrs.to))
-            // TLS cert & key for this domain
+        // TLS cert & key for this domain
             self.credentials = credentials[streamAttrs.to];
         // No credentials means we cannot <starttls/> on the server
         // side. Unfortunately this is required for XMPP 1.0.
@@ -107,7 +117,9 @@ exports.IncomingServer = function(stream, credentials) {
     });
     this.addListener('rawStanza', function(stanza) {
         if (stanza.is('starttls', Connection.NS_XMPP_TLS)) {
-            self.send(new ltx.Element('proceed', { xmlns: Connection.NS_XMPP_TLS }));
+            self.send(new ltx.Element('proceed', {
+                xmlns: Connection.NS_XMPP_TLS
+            }));
             self.setSecure(self.credentials, true);
         }
     });
@@ -119,11 +131,11 @@ util.inherits(exports.IncomingServer, Server);
 exports.IncomingServer.prototype.startStream = function() {
     Server.prototype.startStream.call(this);
 
-    if (this.xmppVersion == '1.0') {
-        this.send("<stream:features>");
+    if (this.xmppVersion === '1.0') {
+        this.send('<stream:features>');
         if (this.credentials && !this.isSecure)
             this.send("<starttls xmlns='" + Connection.NS_XMPP_TLS + "'/>");
-        this.send("</stream:features>");
+        this.send('</stream:features>');
     }
 };
 
@@ -143,16 +155,18 @@ exports.OutgoingServer = function(srcDomain, destDomain, credentials) {
         self.startStream();
     });
     this.addListener('streamStart', function(attrs) {
-                         if (attrs.version !== "1.0")
-                             // Don't wait for <stream:features/>
-                             self.emit('auth', 'dialback');
-                     });
+        if (attrs.version !== '1.0')
+        // Don't wait for <stream:features/>
+            self.emit('auth', 'dialback');
+    });
     self.addListener('rawStanza', function(stanza) {
         if (stanza.is('features', Connection.NS_STREAM)) {
             var mechsEl;
             if ((mechsEl = stanza.getChild('mechanisms', NS_XMPP_SASL))) {
                 var mechs = mechsEl.getChildren('mechanism', NS_XMPP_SASL).
-                    map(function(el) { return el.getText(); });
+                map(function(el) {
+                    return el.getText();
+                });
                 if (mechs.indexOf('EXTERNAL') >= 0)
                     self.emit('auth', 'external');
                 else
@@ -165,8 +179,9 @@ exports.OutgoingServer = function(srcDomain, destDomain, credentials) {
     });
 
     var attempt = SRV.connect(this.socket, ['_xmpp-server._tcp',
-                                            '_jabber._tcp'],
-                              destDomain, 5269);
+            '_jabber._tcp'
+        ],
+        destDomain, 5269);
     attempt.addListener('connect', function() {
         self.startParser();
         self.startStream();
@@ -179,8 +194,8 @@ util.inherits(exports.OutgoingServer, Server);
 
 function generateId() {
     var r = new Buffer(16);
-    for(var i = 0; i < r.length; i++) {
-        r[i] = 48 + Math.floor(Math.random() * 10);  // '0'..'9'
+    for (var i = 0; i < r.length; i++) {
+        r[i] = 48 + Math.floor(Math.random() * 10); // '0'..'9'
     }
     return r.toString();
-};
+}

--- a/lib/xmpp/session.js
+++ b/lib/xmpp/session.js
@@ -1,64 +1,68 @@
 'use strict';
 
-var util = require('util')
-  , EventEmitter = require('events').EventEmitter
-  , Connection = require('./connection')
-  , BOSH = require('./bosh')
-  , WebSockets = require('./websockets')
-  , JID = require('./jid').JID
-  , tls = require('tls')
-  , crypto = require('crypto')
-  , SRV = require('./srv')
+var util = require('util'),
+    EventEmitter = require('events').EventEmitter,
+    Connection = require('./connection'),
+    BOSH = require('./bosh'),
+    WebSockets = require('./websockets'),
+    JID = require('./jid').JID,
+    tls = require('tls'),
+    crypto = require('crypto'),
+    SRV = require('./srv');
 
 function Session(opts) {
-    var self = this
-    EventEmitter.call(this)
+    var self = this;
+    EventEmitter.call(this);
 
-    this.jid = (typeof opts.jid === 'string') ? new JID(opts.jid) : opts.jid
-    this.password = opts.password
-    this.preferredSaslMechanism = opts.preferredSaslMechanism
-    this.availableSaslMechanisms = []
-    this.api_key = opts.api_key
-    this.access_token = opts.access_token
-    this.oauth2_token = opts.oauth2_token
-    this.oauth2_auth = opts.oauth2_auth
-    this.register = opts.register
+    this.jid = (typeof opts.jid === 'string') ? new JID(opts.jid) : opts.jid;
+    this.password = opts.password;
+    this.preferredSaslMechanism = opts.preferredSaslMechanism;
+    this.availableSaslMechanisms = [];
+    this.api_key = opts.api_key;
+    this.access_token = opts.access_token;
+    this.oauth2_token = opts.oauth2_token;
+    this.oauth2_auth = opts.oauth2_auth;
+    this.register = opts.register;
     if (typeof opts.actAs === 'string') {
-        this.actAs = new JID(opts.actAs)
+        this.actAs = new JID(opts.actAs);
     } else {
-        this.actAs = opts.actAs
+        this.actAs = opts.actAs;
     }
-    delete this.did_bind
-    delete this.did_session
+    delete this.did_bind;
+    delete this.did_session;
 
     if (opts.websocketsURL) {
-        this.connection = new WebSockets.WSConnection(opts.websocketsURL)
+        this.connection = new WebSockets.WSConnection(opts.websocketsURL);
         this.connection.on('connected', function() {
-            if (self.connection.startStream)
-                self.connection.startStream()
-        })
+            if (self.connection.startStream) {
+                self.connection.startStream();
+            }
+        });
     } else if (opts.boshURL) {
         this.connection = new BOSH.BOSHConnection({
             jid: this.jid,
             boshURL: opts.boshURL
-        })
+        });
     } else {
         this.connection = new Connection.Connection({
-            xmlns: { '': opts.xmlns },
+            xmlns: {
+                '': opts.xmlns
+            },
             streamAttrs: {
                 version: '1.0',
                 to: this.jid.domain
             }
-        })
+        });
         var connect = function() {
             if (opts.host) {
                 self.connection.on('connect', function() {
-                    if (self.connection.startStream)
-                        self.connection.startStream()
-                })
+                    if (self.connection.startStream) {
+                        self.connection.startStream();
+                    }
+                });
 
                 if (opts.legacySSL) {
-                    self.connection.allowTLS = false
+                    self.connection.allowTLS = false;
                     self.connection.socket = tls.connect(
                         opts.port || 5223,
                         opts.host,
@@ -74,72 +78,82 @@ function Session(opts) {
                         self.connection.credentials = crypto
                             .createCredentials(opts.credentials)
                     }
-                    if (opts.disallowTLS) self.connection.allowTLS = false
-                    self.connection.socket.connect(opts.port || 5222, opts.host)
+                    if (opts.disallowTLS) {
+                        self.connection.allowTLS = false;
+                    }
+                    self.connection.socket.connect(opts.port || 5222, opts.host);
                 }
             } else if (!SRV) {
-                throw 'Cannot load SRV'
+                throw 'Cannot load SRV';
             } else {
-                if (opts.legacySSL)
-                    throw 'LegacySSL mode does not support DNS lookups'
-                if (opts.credentials)
-                    self.connection.credentials = crypto.createCredentials(opts.credentials)
-                if (opts.disallowTLS)
+                if (opts.legacySSL) {
+                    throw 'LegacySSL mode does not support DNS lookups';
+                }
+                if (opts.credentials) {
+                    self.connection.credentials = crypto.createCredentials(opts.credentials);
+                }
+                if (opts.disallowTLS) {
                     self.connection.allowTLS = false
-                var attempt = SRV.connect(self.connection.socket,
-                    ['_xmpp-client._tcp'], self.jid.domain, 5222)
+                }
+                var attempt = SRV.connect(self.connection.socket, ['_xmpp-client._tcp'], self.jid.domain, 5222);
                 attempt.addListener(
                     'connect',
                     function() {
-                        if (self.connection.startStream)
-                            self.connection.startStream()
+                        if (self.connection.startStream) {
+                            self.connection.startStream();
+                        }
                     }
                 )
                 attempt.addListener('error', function(e) {
-                    self.emit('error', e)
+                    self.emit('error', e);
                 })
             }
         }
-        if (opts.reconnect) self.reconnect = connect
-        connect()
+        if (opts.reconnect) {
+            self.reconnect = connect;
+        }
+        connect();
     }
-    this.connection.addListener('stanza', this.onStanza.bind(this))
-    this.connection.addListener('drain', this.emit.bind(this, 'drain'))
+    this.connection.addListener('stanza', this.onStanza.bind(this));
+    this.connection.addListener('drain', this.emit.bind(this, 'drain'));
 
     this.connection.addListener('end', function() {
-        self.emit('end')
-    })
+        self.emit('end');
+    });
     this.connection.addListener('close', function() {
-        self.emit('close')
-    })
-
+        self.emit('close');
+    });
     this.connection.addListener('error', function(error) {
         self.emit('error', error)
-    })
+    });
 }
 
-util.inherits(Session, EventEmitter)
+util.inherits(Session, EventEmitter);
 
 Session.prototype.pause = function() {
-    if (this.connection && this.connection.pause)
-        this.connection.pause()
+    if (this.connection && this.connection.pause) {
+        this.connection.pause();
+    }
 }
 
 Session.prototype.resume = function() {
-    if (this.connection && this.connection.resume)
-        this.connection.resume()
+    if (this.connection && this.connection.resume) {
+        this.connection.resume();
+    }
 }
 
 Session.prototype.send = function(stanza) {
-    if (this.connection)
-        this.connection.send(stanza.root())
+    if (this.connection) {
+        this.connection.send(stanza.root());
+    }
 }
 
 Session.prototype.end = function() {
-    if (this.connection)
-        this.connection.end()
+    if (this.connection) {
+        this.connection.end();
+    }
 }
 
 Session.prototype.onStanza = function() {}
 
-exports.Session = Session
+exports.Session = Session;

--- a/lib/xmpp/srv.js
+++ b/lib/xmpp/srv.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var dns = require('dns');
 var EventEmitter = require('events').EventEmitter;
 
@@ -12,13 +14,13 @@ function compareNumbers(a, b) {
 }
 
 function groupSrvRecords(addrs) {
-    var groups = {};  // by priority
+    var groups = {}; // by priority
     addrs.forEach(function(addr) {
-                      if (!groups.hasOwnProperty(addr.priority))
-                          groups[addr.priority] = [];
+        if (!groups.hasOwnProperty(addr.priority))
+            groups[addr.priority] = [];
 
-                      groups[addr.priority].push(addr);
-                  });
+        groups[addr.priority].push(addr);
+    });
 
     var result = [];
     Object.keys(groups).sort(compareNumbers).forEach(function(priority) {
@@ -47,7 +49,8 @@ function resolveSrv(name, cb) {
             /* no SRV record, try domain as A */
             cb(err);
         } else {
-            var pending = 0, error, results = [];
+            var pending = 0,
+                error, results = [];
             var cb1 = function(e, addrs1) {
                 error = error || e;
                 results = results.concat(addrs1);
@@ -56,15 +59,17 @@ function resolveSrv(name, cb) {
                     cb(results ? null : error, results);
                 }
             };
-        var gSRV = groupSrvRecords(addrs);
-        pending = gSRV.length;
-        gSRV.forEach(function(addr) {
+            var gSRV = groupSrvRecords(addrs);
+            pending = gSRV.length;
+            gSRV.forEach(function(addr) {
                 resolveHost(addr.name, function(e, a) {
                     if (a)
                         a = a.map(function(a1) {
-                                      return { name: a1,
-                                               port: addr.port };
-                                  });
+                            return {
+                                name: a1,
+                                port: addr.port
+                            };
+                        });
                     cb1(e, a);
                 });
             });
@@ -107,7 +112,7 @@ function tryConnect(socket, addrs, listener) {
             socket.removeListener('connect', onConnect);
             socket.removeListener('error', onError);
             listener.emit('error', error || new Error('No addresses to connect to'));
-    }
+        }
     };
     socket.addListener('connect', onConnect);
     socket.addListener('error', onError);
@@ -131,12 +136,13 @@ exports.connect = function(socket, services, domain, defaultPort) {
             resolveHost(domain, function(error, addrs) {
                 if (addrs && addrs.length > 0) {
                     addrs = addrs.map(function(addr) {
-                        return { name: addr,
-                                 port: defaultPort };
+                        return {
+                            name: addr,
+                            port: defaultPort
+                        };
                     });
                     tryConnect(socket, addrs, listener);
-                }
-                else {
+                } else {
                     listener.emit('error', error || new Error('No addresses resolved for ' + domain));
                 }
             });

--- a/lib/xmpp/stanza.js
+++ b/lib/xmpp/stanza.js
@@ -1,47 +1,47 @@
 'use strict';
 
-var util = require('util')
-  , ltx = require('ltx')
+var util = require('util'),
+    ltx = require('ltx');
 
 function Stanza(name, attrs) {
-    ltx.Element.call(this, name, attrs)
+    ltx.Element.call(this, name, attrs);
 }
 
-util.inherits(Stanza, ltx.Element)
+util.inherits(Stanza, ltx.Element);
 
 /**
  * Common attribute getters/setters for all stanzas
  */
 Stanza.prototype.__defineGetter__('from', function() {
-    return this.attrs.from
+    return this.attrs.from;
 })
 
 Stanza.prototype.__defineSetter__('from', function(from) {
-    this.attrs.from = from
+    this.attrs.from = from;
 })
 
 Stanza.prototype.__defineGetter__('to', function() {
-    return this.attrs.to
+    return this.attrs.to;
 })
 
 Stanza.prototype.__defineSetter__('to', function(to) {
-    this.attrs.to = to
+    this.attrs.to = to;
 })
 
 Stanza.prototype.__defineGetter__('id', function() {
-    return this.attrs.id
+    return this.attrs.id;
 })
 
 Stanza.prototype.__defineSetter__('id', function(id) {
-    this.attrs.id = id
+    this.attrs.id = id;
 })
 
 Stanza.prototype.__defineGetter__('type', function() {
-    return this.attrs.type
+    return this.attrs.type;
 })
 
 Stanza.prototype.__defineSetter__('type', function(type) {
-    this.attrs.type = type
+    this.attrs.type = type;
 })
 
 /**
@@ -49,24 +49,24 @@ Stanza.prototype.__defineSetter__('type', function(type) {
  */
 
 function Message(attrs) {
-    Stanza.call(this, 'message', attrs)
+    Stanza.call(this, 'message', attrs);
 }
 
-util.inherits(Message, Stanza)
+util.inherits(Message, Stanza);
 
 function Presence(attrs) {
-    Stanza.call(this, 'presence', attrs)
+    Stanza.call(this, 'presence', attrs);
 }
 
-util.inherits(Presence, Stanza)
+util.inherits(Presence, Stanza);
 
 function Iq(attrs) {
-    Stanza.call(this, 'iq', attrs)
+    Stanza.call(this, 'iq', attrs);
 }
 
-util.inherits(Iq, Stanza)
+util.inherits(Iq, Stanza);
 
-exports.Stanza = Stanza
-exports.Message = Message
-exports.Presence = Presence
-exports.Iq = Iq
+exports.Stanza = Stanza;
+exports.Message = Message;
+exports.Presence = Presence;
+exports.Iq = Iq;

--- a/lib/xmpp/stream_parser.js
+++ b/lib/xmpp/stream_parser.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var util = require('util');
 var EventEmitter = require('events').EventEmitter;
 var ltx = require('ltx');
@@ -24,57 +26,59 @@ function StreamParser(maxStanzaSize) {
 
     this.parser.addListener('startElement', function(name, attrs) {
         // TODO: refuse anything but <stream:stream>
-        if (!self.element && name == 'stream:stream') {
+        if (!self.element && name === 'stream:stream') {
             self.emit('streamStart', attrs);
         } else {
-        var child;
+            var child;
             if (!self.element) {
                 /* A new stanza */
-        child = new Stanza(name, attrs);
+                child = new Stanza(name, attrs);
                 self.element = child;
-        /* For maxStanzaSize enforcement */
+                /* For maxStanzaSize enforcement */
                 self.bytesParsedOnStanzaBegin = self.bytesParsed;
             } else {
                 /* A child element of a stanza */
-        child = new ltx.Element(name, attrs);
+                child = new ltx.Element(name, attrs);
                 self.element = self.element.cnode(child);
             }
         }
     });
 
     this.parser.addListener('endElement', function(name) {
-        if (!self.element && name == 'stream:stream') {
+        if (!self.element && name === 'stream:stream') {
             self.end();
-        } else if (self.element && name == self.element.name) {
-            if (self.element.parent)
+        } else if (self.element && name === self.element.name) {
+            if (self.element.parent) {
                 self.element = self.element.parent;
+            }
             else {
                 /* Stanza complete */
                 self.emit('stanza', self.element);
                 delete self.element;
-        /* maxStanzaSize doesn't apply until next startElement */
+                /* maxStanzaSize doesn't apply until next startElement */
                 delete self.bytesParsedOnStanzaBegin;
             }
         } else {
             self.error('xml-not-well-formed', 'XML parse error');
         }
     });
-    
+
     this.parser.addListener('text', function(str) {
-        if (self.element)
+        if (self.element) {
             self.element.t(str);
+        }
     });
-    
+
     this.parser.addListener('entityDecl', function() {
-    /* Entity declarations are forbidden in XMPP. We must abort to
-     * avoid a billion laughs.
-     */
-    self.error('xml-not-well-formed', 'No entity declarations allowed');
-    self.end();
+        /* Entity declarations are forbidden in XMPP. We must abort to
+         * avoid a billion laughs.
+         */
+        self.error('xml-not-well-formed', 'No entity declarations allowed');
+        self.end();
     });
 
     this.parser.addListener('error', function(error) {
-    self.emit('error', error);
+        self.emit('error', error);
     });
 }
 util.inherits(StreamParser, EventEmitter);
@@ -85,7 +89,7 @@ StreamParser.prototype.write = function(data) {
     data = data.replace(/\/>$/, ">");
     }*/
     if (this.parser) {
-    /* If a maxStanzaSize is configured, the current stanza must consist only of this many bytes */
+        /* If a maxStanzaSize is configured, the current stanza must consist only of this many bytes */
         if (this.bytesParsedOnStanzaBegin && this.maxStanzaSize &&
             this.bytesParsed > this.bytesParsedOnStanzaBegin + this.maxStanzaSize) {
 

--- a/lib/xmpp/websockets.js
+++ b/lib/xmpp/websockets.js
@@ -1,11 +1,13 @@
-var EventEmitter = require('events').EventEmitter;
-var util = require('util');
-var ltx = require('ltx');
-var StreamParser = require('./stream_parser');
-var WebSocket = require('faye-websocket') ?
-                require('faye-websocket').Client :
-                window.WebSocket;
+'use strict';
 
+var EventEmitter = require('events').EventEmitter,
+    util = require('util'),
+    ltx = require('ltx'),
+    StreamParser = require('./stream_parser');
+
+var WebSocket = require('faye-websocket') ?
+    require('faye-websocket').Client :
+    window.WebSocket;
 
 var NS_STREAM = exports.NS_STREAM = 'http://etherx.jabber.org/streams';
 var NS_XMPP_STREAMS = 'urn:ietf:params:xml:ns:xmpp-streams';
@@ -39,9 +41,9 @@ WSConnection.prototype.startParser = function() {
         self.streamAttrs = attrs;
         /* We need those xmlns often, store them extra */
         self.streamNsAttrs = {};
-        for(var k in attrs) {
-        if (k == 'xmlns' ||
-            k.substr(0, 6) == 'xmlns:')
+        for (var k in attrs) {
+            if (k == 'xmlns' ||
+                k.substr(0, 6) === 'xmlns:')
                 self.streamNsAttrs[k] = attrs[k];
         }
 
@@ -63,16 +65,16 @@ WSConnection.prototype.startParser = function() {
 
 WSConnection.prototype.stopParser = function() {
     /* No more events, please (may happen however) */
-    if(this.parser) {
+    if (this.parser) {
         /* Get GC'ed */
         delete this.parser;
     }
 };
 
 WSConnection.prototype.onmessage = function(msg) {
-    console.log("ws msg", msg.data);
+    console.log('ws msg', msg.data);
     if (msg && msg.data && this.parser)
-    this.parser.write(msg.data);
+        this.parser.write(msg.data);
 };
 
 WSConnection.prototype.onStanza = function(stanza) {
@@ -86,7 +88,7 @@ WSConnection.prototype.onStanza = function(stanza) {
 
 WSConnection.prototype.startStream = function() {
     var attrs = {};
-    for(var k in this.xmlns) {
+    for (var k in this.xmlns) {
         if (this.xmlns.hasOwnProperty(k)) {
             if (!k)
                 attrs.xmlns = this.xmlns[k];
@@ -111,20 +113,21 @@ WSConnection.prototype.startStream = function() {
 };
 
 WSConnection.prototype.send = function(stanza) {
-    if (stanza.root)
-    stanza = stanza.root();
+    if (stanza.root) {
+        stanza = stanza.root();
+    }
     stanza = stanza.toString();
-    console.log("ws send", stanza);
+    console.log('ws send', stanza);
     this.websocket.send(stanza);
 };
 
-WSConnection.prototype.onclose = function() {
-};
+WSConnection.prototype.onclose = function() {};
 
 WSConnection.prototype.end = function() {
-    this.send("</stream:stream>");
-    if (this.websocket)
-    this.websocket.close();
+    this.send('</stream:stream>');
+    if (this.websocket) {
+        this.websocket.close();
+    }
 };
 
 WSConnection.prototype.onerror = function(e) {


### PR DESCRIPTION
This pr cleans up a lot of jshint issues and focus on syntax issues only. I have not changed the behavior of the source code.

Within the `contribution.md` we mention:
- Unless required **no semicolons** they are not required
- Short one-line `if` statements do not require nipple brackets (provided functionality is clear)

I changed those, because within a core xmpp lib we should not focus on beauty of code but on stability. Therefore I propose to change this. In case you do not agree we need to change the `.jshintrc` to meet our coding standard.

For the time being I excluded the `examples` from jshint test.
