### PR TITLE
fix browser bugs

### DIFF
--- a/lib/node-xmpp-browserify.js
+++ b/lib/node-xmpp-browserify.js
@@ -1,5 +1,5 @@
 var Connection = require('./xmpp/connection')
-  , Client = require('./xmpp/client').client
+  , Client = require('./xmpp/client').Client
   , JID = require('./xmpp/jid')
   , ltx = require('ltx')
   , Stanza = require('./xmpp/stanza')

--- a/lib/xmpp/websockets.js
+++ b/lib/xmpp/websockets.js
@@ -4,7 +4,7 @@ var EventEmitter = require('events').EventEmitter
   , util = require('util')
   , ltx = require('ltx')
   , StreamParser = require('./stream_parser')
-  , WebSocket = require('faye-websocket') ?
+  , WebSocket = require('faye-websocket') && require('faye-websocket').Client ?
       require('faye-websocket').Client : window.WebSocket
 
 


### PR DESCRIPTION
Fix two bugs from browser 

The first one cause XMPP.Client undefined in browser. As i mentioned in [issue#196](https://github.com/node-xmpp/node-xmpp/issues/196)

The second , if `faye-websocket` is not installed , the `require('faye-websocket')` in browserify is an Plain Object , and is TRUE , and  `require('faye-websocket').Client` is undefined .
