### PR TITLE
make user able to send xml string directly instead of ltx object

### DIFF
--- a/lib/xmpp/session.js
+++ b/lib/xmpp/session.js
@@ -166,7 +166,10 @@ Session.prototype.resume = function() {
 
 Session.prototype.send = function(stanza) {
     if (this.connection)
-        this.connection.send(stanza.root())
+        if (stanza.root)
+            this.connection.send(stanza.root())
+        else
+            this.connection.send(stanza)
 }
 
 Session.prototype.end = function() {


### PR DESCRIPTION
when node xmpp deals with facebook XMPP account, it can not send unicode message properly.
but if you send a xmpp xml string  something like `<message to="-100003824051118@chat.facebook.com" type="chat"><body>호랑이</body></message>` instead of stanza(ltx generated object) then you can send unicode message perfectly.

and also, Connection.send function checks whether if its stanza parameter has root property in order to serialize stanza but Session.send function drops the stanza if it has no root property. I think it does not make sense.
