### PR TITLE
Missing comma in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
   ],
   "engine": "node >=0.8.0",
   "scripts": {
-    "test": "grunt test"
+    "test": "grunt test",
     "browserify": "browserify -d -o node-xmpp-browser.js -r request:browser-request -i node-stringprep -i faye-websocket -i ./srv -i dns ./lib/node-xmpp-browserify.js"
   }
 }


### PR DESCRIPTION
Makes `npm install` work again when you clone `master` :-)
