### PR TITLE
use my fork of pem for now to add subjectAltNames to the test certificate

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "mocha": ">=1.0.0",
-    "pem": ">=1.2.2",
+    "pem": "https://github.com/dodo/pem/tarball/altNames",
     "grunt": "~0.4.1",
     "grunt-contrib-jshint": "~0.6.0",
     "grunt-mocha-cli": "~1.3.0",

--- a/test/tls-test.js
+++ b/test/tls-test.js
@@ -12,7 +12,12 @@ var user = {
 var tls
 
 before(function (done) {
-    pem.createCertificate({ days: 1, selfSigned: true }, function (err, keys) {
+    var cert_params = {
+        days: 1,
+        selfSigned: true,
+        altNames: ["DNS = localhost", "IP = 127.0.0.1"],
+    }
+    pem.createCertificate(cert_params, function (err, keys) {
         if (err) return done(err)
         tls = { key: keys.serviceKey + '\n', cert: keys.certificate + '\n' }
         tls.ca = tls.cert


### PR DESCRIPTION
`tls.createSecurePair` is deprecated since node v0.11
