### PR TITLE
Fixing "register" case in `examples/c2s.js`

### DIFF
--- a/examples/c2s.js
+++ b/examples/c2s.js
@@ -26,7 +26,7 @@ c2s.on('connect', function(client) {
     // That's the way you add mods to a given server.
 
     // Allows the developer to register the jid against anything they want
-    c2s.on('register', function(opts, cb) {
+    client.on('register', function(opts, cb) {
         console.log('REGISTER')
         cb(true)
     })


### PR DESCRIPTION
"c2s" example didn't work. I found that the "register" event is emitted by the client, not the server.
