### PR TITLE
Fix DigestMD5 that used client function to check the SASL response.

### DIFF
--- a/packages/node-xmpp-server/lib/C2S/authentication/DigestMD5.js
+++ b/packages/node-xmpp-server/lib/C2S/authentication/DigestMD5.js
@@ -193,7 +193,7 @@ DigestMD5.prototype.manageAuth = function (stanza, server) {
       }
       this.authenticate(user, function (err, user) {
         // send final challenge and wait for response from user
-        if (self.response === self.responseValue(new Buffer(stanza.getText(), 'base64'), user.password)) {
+        if (self.checkResponse(new Buffer(stanza.getText(), 'base64'))) {
           var challenge = new Element('challenge', {
             xmlns: NS_XMPP_SASL
           })


### PR DESCRIPTION
Use DigestMD5#checkResponse() to check the response from client,
as stated in the function comment.

Please verify if this commit fulfils the initial design and flow.
I find this change makes sense, and works fine with node-xmpp-bosh and strophejs.