### PR TITLE
Handle error during socket connecting

### DIFF
--- a/packages/connection/index.js
+++ b/packages/connection/index.js
@@ -73,6 +73,10 @@ class Connection extends EventEmitter {
     }
     listeners.error = error => {
       this.emit('error', error)
+      if (this.status === 'connecting') {
+        listeners.close()
+        this._status('offline')
+      }
     }
     sock.on('data', listeners.data)
     sock.on('error', listeners.error)


### PR DESCRIPTION
When there is an error during `connecting` phase, the `sock.connect` event is not being called, thus `listeners.close` is not being connected.
This code does manual clean-up in this error case.