### PR TITLE
fix args for getMechanism

### DIFF
--- a/packages/plugins/sasl/index.js
+++ b/packages/plugins/sasl/index.js
@@ -83,7 +83,7 @@ module.exports = plugin('sasl', {
     return []
   },
 
-  getMechanism(usable) {
+  getMechanism(offered, usable) {
     return usable[0] // FIXME prefer SHA-1, ... maybe order usable, available, ... by preferred?
   },
 


### PR DESCRIPTION
Hello! Method getMechanism called in line 58 with 4 parameters
```
this.getMechanism(offered, usable, available, features)
```
but it accepts only one
```
getMechanism(usable) {
  return usable[0] // FIXME prefer SHA-1, ... maybe order usable, available, ... by preferred?
}
```
Usable mechanisms must be accepted in second paramenter.