### PR TITLE
send presence when it gets online

### DIFF
--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -46,6 +46,9 @@ xmpp.on('offline', () => {
 })
 
 xmpp.on('online', async address => {
+  // shows itself online
+  xmpp.send(xml('presence'))
+  
   console.log('🗸', 'online as', address.toString())
 
   // Sends a chat message to itself


### PR DESCRIPTION
I realized that it doesn't show ONLINE on buddies, when I add this, it is working great. By the way, I have an other 'buddy' account which is online via Adium, and Adium XML console shows that xmppjs client sends a presence with a type 'unavailable' like this:

```
<presence xmlns='jabber:client' type='unavailable' from='testuser1@example.net/example' to='testuser2@example.net'/>
```

Maybe this is the origin of the problem.
