### PR TITLE
fix error in docs

### DIFF
--- a/packages/client/example.js
+++ b/packages/client/example.js
@@ -37,7 +37,7 @@ xmpp.on('online', async address => {
   const message = xml(
     'message',
     {type: 'chat', to: address},
-    xml('body', 'hello world')
+    xml('body', null, 'hello world')
   )
   await xmpp.send(message)
 })


### PR DESCRIPTION
`xml('body', 'hello world')` actually translates to `<body xmlns="hello world"/> `, because of how `@xmpp/xml` is actually implemented: `function x(name, attrs, ...children)`. It should be `xml('body', null, 'hello world')`, so 'hello world' actually ends in a `children` argument. Then it actually translates to `<body>hello world</body>` and can be received by some client.