### PR TITLE
Change connection online detection

### DIFF
--- a/packages/connection/index.js
+++ b/packages/connection/index.js
@@ -180,7 +180,7 @@ class Connection extends EventEmitter {
    * Opens the socket then opens the stream
    */
   async start() {
-    if (this.status !== 'offline') {
+    if (this.socket) {
       throw new Error('Connection is not offline')
     }
 


### PR DESCRIPTION
Hey there, I was having a problem where the connection was incorrectly reporting that it was online once the network connection went down. Looking in the code, this is due to the 'error' being emitted, which doesn't reset the the connection. My external library picks up this error callback to then attempt automatic reconnection.

I was unsure about adding reset to error and noticed that socket of null is always true when there is a disconnection. Either this PR should be accepted or another appropriate solution proposed.

Thanks.