### PR TITLE
Add fakeIncomingSet to test framework

### DIFF
--- a/packages/test/context.js
+++ b/packages/test/context.js
@@ -85,6 +85,17 @@ module.exports = function context(entity = client()) {
         return child
       })
     },
+    fakeIncomingSet(context, child, attrs = {}) {
+      attrs.type = 'set'
+      return context.fakeIncomingIq(xml('iq', attrs, child)).then(stanza => {
+        const [child] = stanza.children
+        if (child) {
+          child.parent = null
+        }
+
+        return child
+      })
+    },
     fakeIncomingResult(child, id) {
       return this.fakeIncomingIq(xml('iq', {type: 'result', id}, child)).then(
         stanza => {


### PR DESCRIPTION
In the last big refactoring fakeIncomingSet appears to have been lost.