### PR TITLE
Correct fakeIncomingSet API

### DIFF
--- a/packages/test/context.js
+++ b/packages/test/context.js
@@ -85,9 +85,9 @@ module.exports = function context(entity = client()) {
         return child
       })
     },
-    fakeIncomingSet(context, child, attrs = {}) {
+    fakeIncomingSet(child, attrs = {}) {
       attrs.type = 'set'
-      return context.fakeIncomingIq(xml('iq', attrs, child)).then(stanza => {
+      return this.fakeIncomingIq(xml('iq', attrs, child)).then(stanza => {
         const [child] = stanza.children
         if (child) {
           child.parent = null


### PR DESCRIPTION
This fixes a mistake from #640: fakeIncomingSet should not take `context` as a parameter, but use `this` instead.
