### PR TITLE
connection: implement see-other-host

### DIFF
--- a/packages/connection-tcp/index.js
+++ b/packages/connection-tcp/index.js
@@ -3,20 +3,16 @@
 const {Socket} = require('net')
 const Connection = require('@xmpp/connection')
 const {Parser} = require('@xmpp/xml')
+const {parseURI} = require('@xmpp/connection/lib/util')
 
 const NS_STREAM = 'http://etherx.jabber.org/streams'
 
 /* References
  * Extensible Messaging and Presence Protocol (XMPP): Core http://xmpp.org/rfcs/rfc6120.html
  */
-
 class ConnectionTCP extends Connection {
   socketParameters(service) {
-    let {port, hostname, protocol} = new URL(service)
-    // https://github.com/nodejs/node/issues/12410#issuecomment-294138912
-    if (hostname === '[::1]') {
-      hostname = '::1'
-    }
+    const {port, hostname, protocol} = parseURI(service)
 
     return protocol === 'xmpp:'
       ? {port: port ? Number(port) : null, host: hostname}

--- a/packages/connection-tcp/package.json
+++ b/packages/connection-tcp/package.json
@@ -13,7 +13,6 @@
   ],
   "dependencies": {
     "@xmpp/connection": "^0.7.4",
-    "@xmpp/streamparser": "^0.0.6",
     "@xmpp/xml": "^0.7.4"
   },
   "engines": {

--- a/packages/connection/lib/util.js
+++ b/packages/connection/lib/util.js
@@ -1,0 +1,22 @@
+'use strict'
+
+function parseURI(URI) {
+  let {port, hostname, protocol} = new URL(URI)
+  // https://github.com/nodejs/node/issues/12410#issuecomment-294138912
+  if (hostname === '[::1]') {
+    hostname = '::1'
+  }
+
+  return {port, hostname, protocol}
+}
+
+function parseHost(host) {
+  const {port, hostname} = parseURI(`http://${host}`)
+  return {port, hostname}
+}
+
+function parseService(service) {
+  return service.includes('://') ? parseURI(service) : parseHost(service)
+}
+
+Object.assign(module.exports, {parseURI, parseHost, parseService})

--- a/packages/connection/package.json
+++ b/packages/connection/package.json
@@ -14,7 +14,6 @@
     "@xmpp/error": "^0.7.0",
     "@xmpp/events": "^0.7.0",
     "@xmpp/jid": "^0.7.4",
-    "@xmpp/streamparser": "^0.0.6",
     "@xmpp/xml": "^0.7.4"
   },
   "engines": {

--- a/packages/tls/lib/Connection.js
+++ b/packages/tls/lib/Connection.js
@@ -1,16 +1,12 @@
 'use strict'
 
 const tls = require('tls')
+const {parseURI} = require('@xmpp/connection/lib/util')
 const ConnectionTCP = require('@xmpp/connection-tcp')
 
 class ConnectionTLS extends ConnectionTCP {
   socketParameters(service) {
-    let {port, hostname, protocol} = new URL(service)
-    // https://github.com/nodejs/node/issues/12410#issuecomment-294138912
-    if (hostname === '[::1]') {
-      hostname = '::1'
-    }
-
+    const {port, hostname, protocol} = parseURI(service)
     return protocol === 'xmpps:'
       ? {port: Number(port) || 5223, host: hostname}
       : undefined

--- a/packages/tls/package.json
+++ b/packages/tls/package.json
@@ -7,6 +7,7 @@
   "version": "0.7.4",
   "license": "ISC",
   "dependencies": {
+    "@xmpp/connection": "^0.7.4",
     "@xmpp/connection-tcp": "^0.7.4"
   },
   "keywords": [

--- a/test/see-other-host.js
+++ b/test/see-other-host.js
@@ -1,0 +1,54 @@
+'use strict'
+
+const test = require('ava')
+const {client, jid} = require('../packages/client')
+const debug = require('../packages/debug')
+const server = require('../server')
+
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'
+
+const username = 'client'
+const password = 'foobar'
+const credentials = {username, password}
+const domain = 'localhost'
+const JID = jid(username, domain).toString()
+
+test.beforeEach(() => {
+  return server.restart()
+})
+
+test.afterEach(t => {
+  if (t.context.xmpp && t.context.xmpp.status === 'online') {
+    return t.context.xmpp.stop()
+  }
+})
+
+test.serial.only('see-other-host', async t => {
+  const net = require('net')
+  const Connection = require('../packages/connection-tcp')
+  const {promise} = require('../packages/events')
+
+  const seeOtherHostServer = net.createServer(socket => {
+    const conn = new Connection()
+    conn._attachSocket(socket)
+    const parser = new conn.Parser()
+    conn._attachParser(parser)
+    parser.on('start', () => {
+      const openEl = conn.headerElement()
+      openEl.attrs.from = 'localhost'
+      conn.write(conn.header(openEl))
+      conn._streamError('see-other-host', 'localhost:5222')
+    })
+    socket.on('close', () => {
+      seeOtherHostServer.close()
+    })
+  })
+  seeOtherHostServer.listen(5486)
+  await promise(seeOtherHostServer, 'listening')
+
+  const xmpp = client({credentials, service: 'xmpp://localhost:5486'})
+  debug(xmpp, true)
+  t.context.xmpp = xmpp
+  const address = await xmpp.start()
+  t.is(address.bare().toString(), JID)
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1676,21 +1676,6 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.0.8.tgz#551466be11b2adc3f3d47156758f610bd9f6b1d8"
   integrity sha512-b8bbUOTwzIY3V5vDTY1fIJ+ePKDUBqt2hC2woVGotdQQhG/2Sh62HOKHrT7ab+VerXAcPyAiTEipPu/FsreUtg==
 
-"@xmpp/streamparser@^0.0.6":
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/@xmpp/streamparser/-/streamparser-0.0.6.tgz#118033ea9db7c86a1cb46103f269ebff79f6f1ea"
-  dependencies:
-    "@xmpp/xml" "^0.1.3"
-    inherits "^2.0.3"
-    ltx "^2.5.0"
-
-"@xmpp/xml@^0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@xmpp/xml/-/xml-0.1.3.tgz#1f14399e53e419688558698f6c62e71e39a86a6e"
-  dependencies:
-    inherits "^2.0.3"
-    ltx "^2.6.2"
-
 "@zkochan/cmd-shim@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@zkochan/cmd-shim/-/cmd-shim-3.1.0.tgz#2ab8ed81f5bb5452a85f25758eb9b8681982fd2e"
@@ -5637,7 +5622,7 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
-ltx@^2.5.0, ltx@^2.6.2, ltx@^2.8.1:
+ltx@^2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/ltx/-/ltx-2.8.1.tgz#5ab2770eb9e6d0a78dbed29416d706d8742b6658"
   dependencies:


### PR DESCRIPTION
Used at least by Tigase for clustered WebSocket/BOSH/TCP.


https://github.com/tigase/tigase-server/search?q=see_other_host_strategy&unscoped_q=see_other_host_strategy

See also https://github.com/xmppjs/xmpp.js/issues/781
