### PR TITLE
Ignore exceptions thrown by emit('error', ..)

### DIFF
--- a/packages/component/index.js
+++ b/packages/component/index.js
@@ -26,7 +26,10 @@ function component(options) {
         await entity.authenticate(id, password)
       }
     } catch (err) {
-      entity.emit('error', err)
+      try {
+        entity.emit('error', err)
+        // eslint-disable-next-line no-unused-vars
+      } catch (err) {}
     }
   })
 

--- a/packages/connection/index.js
+++ b/packages/connection/index.js
@@ -94,7 +94,10 @@ class Connection extends EventEmitter {
     }
 
     listeners.error = error => {
-      this.emit('error', error)
+      try {
+        this.emit('error', error)
+        // eslint-disable-next-line no-unused-vars
+      } catch (err) {}
     }
 
     sock.on('close', listeners.close)
@@ -129,7 +132,10 @@ class Connection extends EventEmitter {
     if (error.condition === 'see-other-host') {
       this._onSeeOtherHost(error)
     } else {
-      this.emit('error', error)
+      try {
+        this.emit('error', error)
+        // eslint-disable-next-line no-unused-vars
+      } catch (err) {}
     }
 
     // "Stream Errors Are Unrecoverable"
@@ -157,7 +163,10 @@ class Connection extends EventEmitter {
       await this.connect(service)
       await this.open({domain, lang})
     } catch (err) {
-      this.emit('error', err)
+      try {
+        this.emit('error', err)
+        // eslint-disable-next-line no-unused-vars
+      } catch (err) {}
     }
   }
 
@@ -171,7 +180,10 @@ class Connection extends EventEmitter {
 
     listeners.error = error => {
       this._detachParser()
-      this.emit('error', error)
+      try {
+        this.emit('error', error)
+        // eslint-disable-next-line no-unused-vars
+      } catch (err) {}
     }
 
     listeners.end = element => {

--- a/packages/iq/callee.js
+++ b/packages/iq/callee.js
@@ -74,7 +74,11 @@ function iqHandler(entity) {
     try {
       reply = await next()
     } catch (err) {
-      entity.emit('error', err)
+      try {
+        entity.emit('error', err)
+        // eslint-disable-next-line no-unused-vars
+      } catch (err) {}
+
       reply = buildError('cancel', 'internal-server-error')
     }
 

--- a/packages/middleware/index.js
+++ b/packages/middleware/index.js
@@ -16,7 +16,12 @@ function errorHandler(entity) {
   return function(ctx, next) {
     next()
       .then(reply => reply && entity.send(reply))
-      .catch(err => entity.emit('error', err))
+      .catch(err => {
+        try {
+          entity.emit('error', err)
+          // eslint-disable-next-line no-unused-vars
+        } catch (err) {}
+      })
   }
 }
 

--- a/packages/websocket/lib/FramedParser.js
+++ b/packages/websocket/lib/FramedParser.js
@@ -19,7 +19,11 @@ module.exports = class FramedParser extends Parser {
     const {cursor} = this
     if (name !== cursor.name) {
       // <foo></bar>
-      this.emit('error', new XMLError(`${cursor.name} must be closed.`))
+      try {
+        this.emit('error', new XMLError(`${cursor.name} must be closed.`))
+        // eslint-disable-next-line no-unused-vars
+      } catch (err) {}
+
       return
     }
 

--- a/packages/websocket/lib/Socket.js
+++ b/packages/websocket/lib/Socket.js
@@ -37,7 +37,10 @@ class Socket extends EventEmitter {
 
       error.event = event
       error.url = this.url
-      this.emit('error', error)
+      try {
+        this.emit('error', error)
+        // eslint-disable-next-line no-unused-vars
+      } catch (err) {}
     }
 
     listeners.close = event => {

--- a/packages/xml/lib/Parser.js
+++ b/packages/xml/lib/Parser.js
@@ -44,7 +44,11 @@ class Parser extends EventEmitter {
     const {root, cursor} = this
     if (name !== cursor.name) {
       // <foo></bar>
-      this.emit('error', new XMLError(`${cursor.name} must be closed.`))
+      try {
+        this.emit('error', new XMLError(`${cursor.name} must be closed.`))
+        // eslint-disable-next-line no-unused-vars
+      } catch (err) {}
+
       return
     }
 
@@ -66,7 +70,11 @@ class Parser extends EventEmitter {
   onText(str) {
     const {cursor} = this
     if (!cursor) {
-      this.emit('error', new XMLError(`${str} must be a child.`))
+      try {
+        this.emit('error', new XMLError(`${str} must be a child.`))
+        // eslint-disable-next-line no-unused-vars
+      } catch (err) {}
+
       return
     }
 


### PR DESCRIPTION
EventEmitter will raise an exception if there are no handlers registered for an error event. This results in uncaught exceptions on at least socket reconnect attempts.

Fixes #797 