### PR TITLE
connection: fix exceptions in data handlers

### DIFF
--- a/packages/connection/test/onData.js
+++ b/packages/connection/test/onData.js
@@ -3,18 +3,14 @@
 const test = require('ava')
 const Connection = require('..')
 
-test.cb('#_onData', t => {
+test('#_onData', t => {
   t.plan(2)
   const foo = '<foo>'
   const conn = new Connection()
   conn.parser = {
-    write() {
-      throw new Error('foo')
+    write(str) {
+      t.is(str, foo)
     },
-  }
-  conn._streamError = condition => {
-    t.is(condition, 'bad-format')
-    t.end()
   }
 
   conn.on('input', data => {

--- a/packages/connection/test/parserError.js
+++ b/packages/connection/test/parserError.js
@@ -4,8 +4,8 @@ const test = require('ava')
 const Connection = require('..')
 const {EventEmitter} = require('@xmpp/events')
 
-test('calls _detachParser and emits error', t => {
-  t.plan(2)
+test('calls _detachParser, sends a bad-format stream error and emit an error', t => {
+  t.plan(3)
   const conn = new Connection()
   const parser = new EventEmitter()
   conn._attachParser(parser)
@@ -15,8 +15,13 @@ test('calls _detachParser and emits error', t => {
     t.pass()
   }
 
+  conn._streamError = condition => {
+    t.is(condition, 'bad-format')
+  }
+
   conn.on('error', err => {
     t.is(err, error)
   })
+
   parser.emit('error', error)
 })

--- a/packages/xml/index.js
+++ b/packages/xml/index.js
@@ -9,6 +9,7 @@ const {
   escapeXMLText,
   unescapeXMLText,
 } = require('ltx/lib/escape')
+const XMLError = require('./lib/XMLError')
 
 function xml(...args) {
   return x(...args)
@@ -24,4 +25,5 @@ Object.assign(exports, {
   unescapeXML,
   escapeXMLText,
   unescapeXMLText,
+  XMLError,
 })

--- a/packages/xml/lib/Parser.js
+++ b/packages/xml/lib/Parser.js
@@ -3,13 +3,7 @@
 const LtxParser = require('ltx/lib/parsers/ltx')
 const Element = require('./Element')
 const EventEmitter = require('events')
-
-class XMLError extends Error {
-  constructor(...args) {
-    super(...args)
-    this.name = 'XMLError'
-  }
-}
+const XMLError = require('./XMLError')
 
 class Parser extends EventEmitter {
   constructor() {

--- a/packages/xml/lib/XMLError.js
+++ b/packages/xml/lib/XMLError.js
@@ -1,0 +1,8 @@
+'use strict'
+
+module.exports = class XMLError extends Error {
+  constructor(...args) {
+    super(...args)
+    this.name = 'XMLError'
+  }
+}


### PR DESCRIPTION
- Fixes a serious bug with exceptions being swallowed in `element`/`nonza`/`stanza` handlers
- makes stanza handler behave like a proper EventEmitter handler.
- properly handle incoming malformed xml
- fix websocket framed parser malformed xml error

The original code was totally insane, no idea what happened with my brain there.

See https://github.com/xmppjs/xmpp.js/issues/792

Test case:

```js
/* eslint-disable node/no-extraneous-require */

'use strict'

const {client, xml} = require('@xmpp/client')
const debug = require('@xmpp/debug')

const xmpp = client({
  service: 'ws://localhost:5280/ws',
  domain: 'localhost',
  resource: 'example',
  username: 'username',
  password: 'password',
})
debug(xmpp, true)
xmpp.reconnect.stop()

xmpp.on('stanza', stanza => {
  // Throws
  stanza.foo.hello()
})

xmpp.on('online', address => {
  xmpp.send(
    xml('message', {type: 'chat', to: address}, xml('body', {}, 'hello world'))
  )
})

xmpp.start().catch(console.error)
```

Before:

```xml
IN
<iq xmlns="jabber:client" type="result" id="p5v4iu1sav">
  <bind xmlns="urn:ietf:params:xml:ns:xmpp-bind">
    <jid>
      username@localhost/example
    </jid>
  </bind>
</iq>
OUT
<stream:error>
  <bad-format xmlns="urn:ietf:params:xml:ns:xmpp-streams"/>
</stream:error>
status closing 
status online username@localhost/example
(node:34168) UnhandledPromiseRejectionWarning: Error: write EPIPE
    at afterWriteDispatched (internal/stream_base_commons.js:150:25)
    at writevGeneric (internal/stream_base_commons.js:133:3)
    at Socket._writeGeneric (net.js:768:11)
    at Socket._writev (net.js:777:8)
    at doWrite (_stream_writable.js:429:12)
    at clearBuffer (_stream_writable.js:528:5)
    at Socket.Writable.uncork (_stream_writable.js:325:7)
    at Sender.sendFrame (/home/sonny/xmpp/node_modules/ws/lib/sender.js:353:20)
    at Sender.send (/home/sonny/xmpp/node_modules/ws/lib/sender.js:272:12)
    at WebSocket.send (/home/sonny/xmpp/node_modules/ws/lib/websocket.js:354:18)
(node:34168) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:34168) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
status disconnect [object Object]
```

This is totally confusing:

1. Missing outgoing message
2. Missing incoming message
3. Cryptic error
4. Online after stream:error oO

If reconnect is enabled (which it is by default with @xmpp/client) it would just indifintely reconnect if you have an handler that throws...

After:

```xml
IN
<iq xmlns="jabber:client" type="result" id="loe785c9wy">
  <bind xmlns="urn:ietf:params:xml:ns:xmpp-bind">
    <jid>
      username@localhost/example
    </jid>
  </bind>
</iq>
/home/sonny/xmpp/testerror.js:20
  stanza.foo.hello()
             ^

TypeError: Cannot read property 'hello' of undefined
    at Client.<anonymous> (/home/sonny/xmpp/testerror.js:20:14)
    at Client.emit (events.js:210:5)
    at Client._onElement (/home/sonny/xmpp/packages/connection/index.js:117:10)
    at FramedParser.listeners.element (/home/sonny/xmpp/packages/connection/index.js:168:12)
    at FramedParser.emit (events.js:210:5)
    at FramedParser.onEndElement (/home/sonny/xmpp/packages/websocket/lib/FramedParser.js:36:12)
    at SaxLtx.emit (events.js:210:5)
    at SaxLtx._handleTagOpening (/home/sonny/xmpp/node_modules/ltx/lib/parsers/ltx.js:39:12)
    at SaxLtx.write (/home/sonny/xmpp/node_modules/ltx/lib/parsers/ltx.js:151:18)
    at FramedParser.write (/home/sonny/xmpp/packages/xml/lib/Parser.js:77:17)
```

Exception is thrown as expected, logs are correct and behaves like an EventEmitter.