### PR TITLE
support of conditions in the middleware

### DIFF
--- a/ava.config.js
+++ b/ava.config.js
@@ -20,6 +20,9 @@ export default {
     },
   },
   files: [
-    "packages/middleware/test/middleware.js",
+    "packages/**/test.js",
+    "packages/**/test/*.js",
+    "packages/**/*.test.js",
+    "!packages/test/*.js",
   ],
 };

--- a/ava.config.js
+++ b/ava.config.js
@@ -20,9 +20,6 @@ export default {
     },
   },
   files: [
-    "packages/**/test.js",
-    "packages/**/test/*.js",
-    "packages/**/*.test.js",
-    "!packages/test/*.js",
+    "packages/middleware/test/middleware.js",
   ],
 };

--- a/packages/middleware/README.md
+++ b/packages/middleware/README.md
@@ -28,10 +28,32 @@ The `use` method registers a middleware for incoming stanzas.
 app.use((ctx, next) => {});
 ```
 
+You can also specify condition `use([elName], [subName], [subNs], [elType], handler)`
+
+```js
+app.use("message", (ctx, next) => {});
+app.use("message", "x", (ctx, next) => {});
+app.use("message", "x", "http://jabber.org/protocol/muc#user", (ctx, next) => {});
+app.use("message", "x", "http://jabber.org/protocol/muc#user", "chat", (ctx, next) => {});
+app.use("message", "x", "*", "chat", (ctx, next) => {});
+app.use("message", "*", "*", "chat", (ctx, next) => {});
+```
+
 ### filter
 
 The `filter` method registers a middleware for outgoing stanzas.
 
 ```js
 app.filter((ctx, next) => {});
+```
+
+You can also specify condition `filter([elName], [subName], [subNs], [elType], handler)`
+
+```js
+app.filter("message", (ctx, next) => {});
+app.filter("message", "x", (ctx, next) => {});
+app.filter("message", "x", "http://jabber.org/protocol/muc#user", (ctx, next) => {});
+app.filter("message", "x", "http://jabber.org/protocol/muc#user", "chat", (ctx, next) => {});
+app.filter("message", "x", "*", "chat", (ctx, next) => {});
+app.filter("message", "*", "*", "chat", (ctx, next) => {});
 ```

--- a/packages/middleware/index.js
+++ b/packages/middleware/index.js
@@ -1,9 +1,60 @@
+/* eslint prefer-rest-params: "off" */
+
 "use strict";
 
 const compose = require("koa-compose");
 
 const IncomingContext = require("./lib/IncomingContext");
 const OutgoingContext = require("./lib/OutgoingContext");
+
+function condition(elName /* , subName, subNs, elType, handler */) {
+  const args = {
+    handler: arguments[arguments.length - 1],
+    name: elName,
+    type: "*",
+    childName: "*",
+    childNS: "*",
+  };
+
+  if (arguments.length > 2) {
+    args.childName = arguments[1];
+  }
+
+  if (arguments.length > 3) {
+    args.childNS = arguments[2];
+  }
+
+  if (arguments.length > 4) {
+    args.type = arguments[3];
+  }
+
+  return (ctx, next) => {
+    if (ctx.stanza.is(args.name)) {
+      if (args.type === "*" || ctx.type === args.type) {
+        if (args.childName === "*" && args.childNS === "*") {
+          return args.handler(ctx, next);
+        }
+
+        const element = ctx.stanza.getChildrenByFilter((child) => {
+          if (
+            (args.childName === "*" || child.name === args.childName) &&
+            (args.childNS === "*" || child.attrs.xmlns === args.childNS)
+          ) {
+            return child;
+          }
+
+          return false;
+        }, true)[0];
+
+        if (element) {
+          return args.handler(ctx, next);
+        }
+      }
+    }
+
+    return next();
+  };
+}
 
 function listener(entity, middleware, Context) {
   return (stanza) => {
@@ -32,10 +83,18 @@ module.exports = function middleware({ entity }) {
 
   return {
     use(fn) {
+      if (arguments.length > 1) {
+        fn = Reflect.apply(condition, this, arguments);
+      }
+
       incoming.push(fn);
       return fn;
     },
     filter(fn) {
+      if (arguments.length > 1) {
+        fn = Reflect.apply(condition, this, arguments);
+      }
+
       outgoing.push(fn);
       return fn;
     },

--- a/packages/middleware/test/middleware.js
+++ b/packages/middleware/test/middleware.js
@@ -25,6 +25,117 @@ test.cb("use", (t) => {
   t.context.fakeIncoming(stanza);
 });
 
+test.cb("use with name condition", (t) => {
+  t.plan(4);
+  const stanza = <presence />;
+  t.context.middleware.use("presence", (ctx, next) => {
+    t.true(ctx instanceof IncomingContext);
+    t.deepEqual(ctx.stanza, stanza);
+    t.is(ctx.entity, t.context.entity);
+    t.true(next() instanceof Promise);
+    t.end();
+  });
+  t.context.fakeIncoming(stanza);
+});
+
+test.cb("use with name and type condition", (t) => {
+  t.plan(4);
+  const stanza = <message type="chat" />;
+  t.context.middleware.use("message", "*", "*", "chat", (ctx, next) => {
+    t.true(ctx instanceof IncomingContext);
+    t.deepEqual(ctx.stanza, stanza);
+    t.is(ctx.entity, t.context.entity);
+    t.true(next() instanceof Promise);
+    t.end();
+  });
+  t.context.fakeIncoming(stanza);
+});
+
+test.cb("use with name, child name and type condition", (t) => {
+  t.plan(4);
+  const stanza = (
+    <message type="chat">
+      <x />
+    </message>
+  );
+  t.context.middleware.use("message", "x", "*", "chat", (ctx, next) => {
+    t.true(ctx instanceof IncomingContext);
+    t.deepEqual(ctx.stanza, stanza);
+    t.is(ctx.entity, t.context.entity);
+    t.true(next() instanceof Promise);
+    t.end();
+  });
+  t.context.fakeIncoming(stanza);
+});
+
+test.cb("use with name, child name with xmlns and type condition", (t) => {
+  t.plan(4);
+  const stanza = (
+    <message type="chat">
+      <x xmlns="http://jabber.org/protocol/muc#user">
+        <invite />
+      </x>
+    </message>
+  );
+  t.context.middleware.use(
+    "message",
+    "x",
+    "http://jabber.org/protocol/muc#user",
+    "chat",
+    (ctx, next) => {
+      t.true(ctx instanceof IncomingContext);
+      t.deepEqual(ctx.stanza, stanza);
+      t.is(ctx.entity, t.context.entity);
+      t.true(next() instanceof Promise);
+      t.end();
+    },
+  );
+  t.context.fakeIncoming(stanza);
+});
+
+test.cb("use with name, child name with xmlns without type condition", (t) => {
+  t.plan(4);
+  const stanza = (
+    <message type="chat">
+      <x xmlns="http://jabber.org/protocol/muc#user">
+        <invite />
+      </x>
+    </message>
+  );
+  t.context.middleware.use(
+    "message",
+    "x",
+    "http://jabber.org/protocol/muc#user",
+    (ctx, next) => {
+      t.true(ctx instanceof IncomingContext);
+      t.deepEqual(ctx.stanza, stanza);
+      t.is(ctx.entity, t.context.entity);
+      t.true(next() instanceof Promise);
+      t.end();
+    },
+  );
+  t.context.fakeIncoming(stanza);
+});
+
+test.cb("use with name, child name without xmlns and type condition", (t) => {
+  t.plan(4);
+  const stanza = (
+    <message type="chat">
+      <x xmlns="http://jabber.org/protocol/muc#user">
+        <invite />
+      </x>
+    </message>
+  );
+  t.context.middleware.use("message", "x", (ctx, next) => {
+    t.true(ctx instanceof IncomingContext);
+    t.deepEqual(ctx.stanza, stanza);
+    t.is(ctx.entity, t.context.entity);
+    t.true(next() instanceof Promise);
+    t.end();
+  });
+  t.context.fakeIncoming(stanza);
+});
+
 test.cb("filter", (t) => {
   t.plan(4);
   const stanza = <presence />;
@@ -37,6 +148,31 @@ test.cb("filter", (t) => {
     t.end();
   });
   /* eslint-enable array-callback-return */
+  t.context.fakeOutgoing(stanza);
+});
+
+test.cb("filter with name, child name with xmlns and type condition", (t) => {
+  t.plan(4);
+  const stanza = (
+    <message type="chat">
+      <x xmlns="http://jabber.org/protocol/muc#user">
+        <invite />
+      </x>
+    </message>
+  );
+  t.context.middleware.filter(
+    "message",
+    "x",
+    "http://jabber.org/protocol/muc#user",
+    "chat",
+    (ctx, next) => {
+      t.true(ctx instanceof OutgoingContext);
+      t.deepEqual(ctx.stanza, stanza);
+      t.is(ctx.entity, t.context.entity);
+      t.true(next() instanceof Promise);
+      t.end();
+    },
+  );
   t.context.fakeOutgoing(stanza);
 });
 


### PR DESCRIPTION
The main motivation is to get rid of the checks in the middleware handler.
This pattern is traced in many parts of the code

for example
https://github.com/xmppjs/xmpp.js/blob/f0dd463102143cdc3dacdcab7a1921bab0ff0cd7/packages/iq/callee.js#L109
https://github.com/xmppjs/xmpp.js/blob/f0dd463102143cdc3dacdcab7a1921bab0ff0cd7/packages/stream-features/index.js#L13

and also regularly have to write conditions in their logic

backward compatibility fully preserved


