### PR TITLE
Add 'Getting help' section to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ We avoid third party dependencies.
 
 For the web, we make the sure the default [client](/packages/client) doesn't exceed 15 kb (gzipped), for reference, that's less than half the size of [React](https://reactjs.org/blog/2017/09/26/react-v16.0.html#reduced-file-size).
 
+## Getting help
+
+Do you need help with working with xmpp.js? Please reach out to our community by posting in the [Discussions section](https://github.com/xmppjs/xmpp.js/discussions) of this project.
+
 ## Built with xmpp.js
 
 - [Simplo](https://simplo.app/?lang=en)


### PR DESCRIPTION
As many Github projects have features enabled that they don't use, some people (like me) don't bother flipping through all tabs on the Github project home page, assuming that most of them will be empty anyways. If I wasn't aware that the Discussions Github feature is actively being used by this project, then at least some portion of other newcomers likely won't be either.

This commit adds a stupidly simple pointer for "where do I go when I need help" as a new section in the readme, to help guide people like me.