### PR TITLE
stream-management: await the enable stanza

### DIFF
--- a/packages/stream-management/index.js
+++ b/packages/stream-management/index.js
@@ -7,7 +7,7 @@ const xml = require("@xmpp/xml");
 const NS = "urn:xmpp:sm:3";
 
 async function enable(entity, resume, max) {
-  entity.send(
+  await entity.send(
     xml("enable", { xmlns: NS, max, resume: resume ? "true" : undefined }),
   );
 

--- a/packages/stream-management/test.js
+++ b/packages/stream-management/test.js
@@ -25,6 +25,8 @@ test("enable - enabled", async (t) => {
     <enable xmlns="urn:xmpp:sm:3" resume="true" />,
   );
 
+  await tick();
+
   t.is(entity.streamManagement.outbound, 0);
   t.is(entity.streamManagement.enabled, false);
   t.is(entity.streamManagement.id, "");
@@ -42,6 +44,25 @@ test("enable - enabled", async (t) => {
 
   t.is(entity.streamManagement.id, "some-long-sm-id");
   t.is(entity.streamManagement.enabled, true);
+});
+
+test("enable - send rejects", async (t) => {
+  const { entity } = mockClient();
+
+  entity.send = () => Promise.reject(new Error("nope"));
+
+  entity.mockInput(
+    <enabled
+      xmlns="urn:xmpp:sm:3"
+      id="some-long-sm-id"
+      location="[2001:41D0:1:A49b::1]:9222"
+      resume="true"
+    />,
+  );
+
+  await tick();
+
+  t.is(entity.streamManagement.enabled, false);
 });
 
 test("enable - message - enabled", async (t) => {
@@ -63,6 +84,8 @@ test("enable - message - enabled", async (t) => {
   t.is(entity.streamManagement.outbound, 0);
   t.is(entity.streamManagement.enabled, false);
   t.is(entity.streamManagement.id, "");
+
+  await tick();
 
   entity.mockInput(<message />);
 
@@ -102,6 +125,8 @@ test("enable - failed", async (t) => {
 
   t.is(entity.streamManagement.outbound, 0);
   entity.streamManagement.enabled = true;
+
+  await tick();
 
   entity.mockInput(<failed xmlns="urn:xmpp:sm:3" />);
 


### PR DESCRIPTION
Trying to await the sending of an "enable" stanza to fix a "Uncaught exception" (see #961).

The attempt is currently failing because I'm kind of a newbie regarding Ava and the testing framework.

I tried to write a test with a client that rejects the "send", but could not really manage to have that working.
I'm not 100% sure if I'm mocking the client correctly, nor if the error is supposed to be triggered by the "tick" function actually.
I'm also not sure I'm using `t.throwsAsync` correctly.

Also, adding the "await" keyword to "entity.send" is triggering other tests to fail.

Any pointer/idea/suggestion would be warmly welcome :pray: 