### PR TITLE
Fix Incomming/OutgoingContext to retrieve domain from entity.options

### DIFF
--- a/packages/middleware/lib/IncomingContext.js
+++ b/packages/middleware/lib/IncomingContext.js
@@ -7,7 +7,8 @@ module.exports = class IncomingContext extends Context {
   constructor(entity, stanza) {
     super(entity, stanza);
 
-    const { jid, domain } = entity;
+    const { jid } = entity;
+    const { domain } = entity.options;
 
     const to = stanza.attrs.to || (jid && jid.toString());
     const from = stanza.attrs.from || domain;

--- a/packages/middleware/lib/OutgoingContext.js
+++ b/packages/middleware/lib/OutgoingContext.js
@@ -7,7 +7,8 @@ module.exports = class OutgoingContext extends Context {
   constructor(entity, stanza) {
     super(entity, stanza);
 
-    const { jid, domain } = entity;
+    const { jid } = entity;
+    const { domain } = entity.options;
 
     const from = stanza.attrs.from || (jid && jid.toString());
     const to = stanza.attrs.to || domain;


### PR DESCRIPTION
In the current implementation of Incoming/OutgoingContext, the domain property is being retrieved from the "entity" object. However, the "entity" object inherits from EventEmitter class, which also has a "domain" property. This domain property is the event domain (Domain class), not the XMPP domain (string). The XMPP domain is stored in the "options" property of the "entity" object.