### PR TITLE
fix: restore JID sooner

### DIFF
--- a/packages/stream-management/index.js
+++ b/packages/stream-management/index.js
@@ -92,14 +92,15 @@ module.exports = function streamManagement({
     // Resuming
     if (sm.id) {
       try {
+        entity.jid = address;
         await resume(entity, sm.inbound, sm.id);
         sm.enabled = true;
-        entity.jid = address;
         entity.status = "online";
         return true;
         // If resumption fails, continue with session establishment
         // eslint-disable-next-line no-unused-vars
       } catch {
+        entity.jid = null;
         sm.id = "";
         sm.enabled = false;
         sm.outbound = 0;


### PR DESCRIPTION
This fixes an edge case I ran into involving logic where the client automatically handles reconnecting and resuming the stream.

I needed a way to listen for a stanza or event that indicates the stream is fully restored and can be used to send messages again (for example to try resending messages that were sent while offline)

the `<resumed>` stanza received from the server after a `<resume>` stanza is sent from the client seemed like a good candidate for this, however listening for that event and assuming the JID was available right away was where I was getting buggy behavior.

This change makes sure the JID is restored before sending the `<resume>` stanza but also nulls it out if that fails for whatever reason