### PR TITLE
Fix outgoing "filter" on middleware

### DIFF
--- a/packages/middleware/index.js
+++ b/packages/middleware/index.js
@@ -28,7 +28,7 @@ module.exports = function middleware({ entity }) {
   const outgoingListener = listener(entity, outgoing, OutgoingContext);
 
   entity.on("element", incomingListener);
-  entity.hookOutgoing = outgoingListener;
+  entity.on("send", outgoingListener);
 
   return {
     use(fn) {

--- a/packages/test/context.js
+++ b/packages/test/context.js
@@ -139,7 +139,7 @@ module.exports = function context(entity = client()) {
       return this.sanitize(el).stanza;
     },
     fakeOutgoing(el) {
-      entity.hookOutgoing(el);
+      entity.emit("send", el);
     },
     mockInput(el) {
       entity.emit("input", el.toString());


### PR DESCRIPTION
hookOutgoing doesn't exist, but emit("send", element) does.