### PR TITLE
Don't allow pings to prevent timeout

### DIFF
--- a/packages/stream-management/index.js
+++ b/packages/stream-management/index.js
@@ -124,6 +124,7 @@ export default function streamManagement({
   middleware.use(async (context, next) => {
     const { stanza } = context;
     clearTimeout(timeoutTimeout);
+    timeoutTimeout = null;
     if (["presence", "message", "iq"].includes(stanza.name)) {
       sm.inbound += 1;
     } else if (stanza.is("r", NS)) {
@@ -158,12 +159,11 @@ export default function streamManagement({
   }
 
   function requestAck() {
-    clearTimeout(timeoutTimeout);
     clearTimeout(requestAckTimeout);
 
     if (!sm.enabled) return;
 
-    if (sm.timeout) {
+    if (sm.timeout && !timeoutTimeout) {
       timeoutTimeout = setTimeout(
         () => entity.disconnect().catch(() => {}),
         sm.timeout,


### PR DESCRIPTION
Sending a new request shouldn't clear the waiting-for-reply timeout if we haven't got a reply yet, or else we may never time out at all if we keep sending pings (which we do).