### PR TITLE
Handle incorrect SASL <challenge>s

### DIFF
--- a/packages/sasl2/index.js
+++ b/packages/sasl2/index.js
@@ -46,6 +46,9 @@ async function authenticate({
       if (element.getNS() !== NS) return;
 
       if (element.name === "challenge") {
+        if (!mech.challenge) {
+          throw new Error("${mech.name} does not support SASL challenges");
+        }
         await mech.challenge(decode(element.text()));
         const resp = await mech.response(creds);
         await entity.send(


### PR DESCRIPTION
A malicious/misbehaving server can crash xmpp.js here by offering FAST but then responding to the `<initial-response>` with a `<challenge>` instead of a `<success>` or `<failure>`. That would cause xmpp.js to run

```
        await mech.challenge(decode(element.text()));
```

but `mech.challenge` isn't defined for HT-SHA-256-NONE, which is the one and only FAST mechanism supported at the moment.