### PR TITLE
Mark remaining methods as async

### DIFF
--- a/e2e.config.cjs
+++ b/e2e.config.cjs
@@ -4,5 +4,5 @@
 module.exports = {
   testMatch: ["<rootDir>/test/*.test.js"],
   setupFilesAfterEnv: ["jest-extended/all"],
-  testTimeout: 10_000,
+  testTimeout: 20_000,
 };

--- a/packages/client-core/lib/Client.js
+++ b/packages/client-core/lib/Client.js
@@ -6,11 +6,11 @@ class Client extends Connection {
     this.transports = [];
   }
 
-  send(element, ...args) {
+  async send(element, ...args) {
     return this.Transport.prototype.send.call(this, element, ...args);
   }
 
-  sendMany(...args) {
+  async sendMany(...args) {
     return this.Transport.prototype.sendMany.call(this, ...args);
   }
 
@@ -24,7 +24,7 @@ class Client extends Connection {
     });
   }
 
-  connect(service) {
+  async connect(service) {
     const Transport = this._findTransport(service);
 
     if (!Transport) {

--- a/packages/component-core/lib/Component.js
+++ b/packages/component-core/lib/Component.js
@@ -19,7 +19,7 @@ class Component extends Connection {
   }
 
   // https://xmpp.org/extensions/xep-0114.html#example-4
-  send(el) {
+  async send(el) {
     // All stanzas sent to the server MUST possess a 'from' attribute and a 'to' attribute, as in the 'jabber:server' namespace
     if (this.isStanza(el) && !el.attrs.from) {
       el.attrs.from = this.jid.toString();

--- a/packages/connection/index.js
+++ b/packages/connection/index.js
@@ -313,11 +313,12 @@ class Connection extends EventEmitter {
     this.emit("send", element);
   }
 
-  sendReceive(element, timeout = this.timeout) {
-    return Promise.all([
+  async sendReceive(element, timeout = this.timeout) {
+    const [, el] = await Promise.all([
       this.send(element),
       promise(this, "element", "error", timeout),
-    ]).then(([, el]) => el);
+    ]);
+    return el;
   }
 
   async write(string) {


### PR DESCRIPTION
A few remaining async methods weren't marked as such

I don't understand fully why but fixes the problem with this line `entity.send(xml("r", { xmlns: NS })).catch(() => {});` throwing an exception.

<img width="622" height="505" alt="Screenshot From 2025-11-12 08-43-48" src="https://github.com/user-attachments/assets/cacb18c4-8f6a-4098-b413-38b5c3f7811d" />

The CI failure with Node.js 25 is unrelated https://github.com/jestjs/jest/issues/15888