### PR TITLE
connection: Fix write impl

### DIFF
--- a/packages/connection/index.js
+++ b/packages/connection/index.js
@@ -332,8 +332,8 @@ class Connection extends EventEmitter {
       throw new Error("Connection is closing");
     }
 
-    return new Promise((resolve, reject) => {
-      this.socket.write(string, (err) => (err ? reject(err) : resolve()));
+    return new Promise((resolve) => {
+      this.socket.write(string, resolve);
     });
   }
 

--- a/packages/test/index.js
+++ b/packages/test/index.js
@@ -1,4 +1,5 @@
 import xml from "@xmpp/xml";
+import clone from "ltx/lib/clone.js";
 import jid from "@xmpp/jid";
 import { delay, promise, timeout } from "@xmpp/events";
 import id from "@xmpp/id";
@@ -20,6 +21,7 @@ export {
   timeout,
   id,
   mockSocket,
+  clone,
 };
 
 export function mockInput(entity, el) {

--- a/packages/websocket/lib/Socket.js
+++ b/packages/websocket/lib/Socket.js
@@ -63,6 +63,6 @@ export default class Socket extends EventEmitter {
 
   write(data, fn) {
     this.socket.send(data);
-    done();
+    Promise.resolve().then(fn);
   }
 }

--- a/packages/websocket/lib/Socket.js
+++ b/packages/websocket/lib/Socket.js
@@ -63,6 +63,8 @@ export default class Socket extends EventEmitter {
 
   write(data, fn) {
     this.socket.send(data);
-    Promise.resolve().then(fn);
+    Promise.resolve()
+      .then(fn)
+      .catch(() => {});
   }
 }

--- a/packages/websocket/lib/Socket.js
+++ b/packages/websocket/lib/Socket.js
@@ -62,18 +62,7 @@ export default class Socket extends EventEmitter {
   }
 
   write(data, fn) {
-    function done(err) {
-      if (!fn) return;
-      // eslint-disable-next-line promise/catch-or-return, promise/no-promise-in-callback
-      Promise.resolve().then(() => fn(err));
-    }
-
-    try {
-      this.socket.send(data);
-    } catch (err) {
-      done(err);
-      return;
-    }
+    this.socket.send(data);
     done();
   }
 }

--- a/packages/websocket/test/test.js
+++ b/packages/websocket/test/test.js
@@ -4,16 +4,19 @@ import xml from "@xmpp/xml";
 import ConnectionWebSocket from "../lib/Connection.js";
 import Socket from "../lib/Socket.js";
 
-test("send()", () => {
+test("send()", async () => {
   const connection = new ConnectionWebSocket();
-  connection.write = () => {};
+  connection.socket = new Socket();
+  connection.socket.socket = {
+    send: jest.fn(),
+  };
   connection.root = xml("root");
 
   const element = xml("presence");
 
   expect(element.attrs.xmlns).toBe(undefined);
   expect(element.parent).toBe(null);
-  connection.send(element);
+  await connection.send(element);
   expect(element.attrs.xmlns).toBe("jabber:client");
   expect(element.parent).toBe(connection.root);
 });
@@ -70,6 +73,9 @@ test("socket close", () => {
 test("sendMany", async () => {
   const conn = new ConnectionWebSocket();
   conn.socket = new Socket();
+  conn.socket.socket = {
+    send: jest.fn(),
+  };
   const spy_write = jest.spyOn(conn.socket, "write");
   conn.root = xml("root");
 
@@ -82,7 +88,7 @@ test("sendMany", async () => {
     expect(element.parent).toBe(null);
   }
 
-  conn.sendMany(elements);
+  await conn.sendMany(elements);
 
   for (const element of elements) {
     expect(element.attrs.xmlns).toBe("jabber:client");


### PR DESCRIPTION
Our Socket impl are meant to mimick Node.js `net`

write should throw error synchronously see https://nodejs.org/api/net.html#socketwritedata-encoding-callback