### PR TITLE
Stop using jsx in tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ test:
 	cd packages/xmpp.js/ && npm run prepublish
 	npm install
 	make bundle
-	npx jest
+	npm run test
 	make lint
 	make bundlesize
 
@@ -40,7 +40,7 @@ e2e:
 	cd server && prosodyctl --config prosody.cfg.lua install mod_sasl2_sm > /dev/null
 	cd server && prosodyctl --config prosody.cfg.lua install mod_sasl2_fast > /dev/null
 	npm run e2e
-	node --test browser.test.js
+	node --test test/browser.js
 
 clean:
 	make stop

--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -4,25 +4,25 @@ module.exports = function config(api) {
   const isTest = api.env("test");
 
   if (isTest) {
-    return {
-      plugins: [
-        [
-          "@babel/plugin-transform-react-jsx",
-          {
-            pragma: "xml",
-            throwIfNamespace: false,
-          },
-        ],
-        [
-          "babel-plugin-jsx-pragmatic",
-          {
-            module: "@xmpp/xml",
-            import: "xml",
-          },
-        ],
-        "@babel/plugin-transform-modules-commonjs",
-      ],
-    };
+    return {};
+    // return {
+    //   plugins: [
+    //     [
+    //       "@babel/plugin-transform-react-jsx",
+    //       {
+    //         pragma: "xml",
+    //         throwIfNamespace: false,
+    //       },
+    //     ],
+    //     [
+    //       "babel-plugin-jsx-pragmatic",
+    //       {
+    //         module: "@xmpp/xml",
+    //         import: "xml",
+    //       },
+    //     ],
+    //   ],
+    // };
   }
 
   return {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -25,11 +25,11 @@ export default [
         ...globals.builtin,
         ...globals["shared-node-browser"],
       },
-      parserOptions: {
-        ecmaFeatures: {
-          jsx: true,
-        },
-      },
+      // parserOptions: {
+      //   ecmaFeatures: {
+      //     jsx: false,
+      //   },
+      // },
       sourceType: "module",
     },
 
@@ -128,6 +128,7 @@ export default [
             "@xmpp/websocket",
             "selfsigned",
             "@xmpp/events",
+            "@jest/globals",
           ],
         },
       ],

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -12,4 +12,5 @@ module.exports = {
     "<rootDir>/packages/test/",
   ],
   setupFilesAfterEnv: ["jest-extended/all"],
+  transform: {},
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,17 +9,14 @@
       ],
       "devDependencies": {
         "@babel/core": "^7.28.5",
-        "@babel/plugin-transform-modules-commonjs": "^7.27.1",
-        "@babel/plugin-transform-react-jsx": "^7.27.1",
         "@babel/plugin-transform-runtime": "^7.28.5",
         "@babel/preset-env": "^7.28.5",
         "@babel/runtime": "^7.28.4",
+        "@jest/globals": "^30.2.0",
         "@rollup/plugin-babel": "^6.1.0",
         "@rollup/plugin-commonjs": "^29.0.0",
         "@rollup/plugin-node-resolve": "^16.0.3",
         "@rollup/plugin-terser": "^0.4.4",
-        "babel-jest": "^30.2.0",
-        "babel-plugin-jsx-pragmatic": "^1.0.2",
         "bytes": "^3.1.2",
         "eslint": "^9.39.1",
         "eslint-config-prettier": "^10.1.8",
@@ -37,6 +34,7 @@
         "lerna": "^9.0.3",
         "lint-staged": "^16.2.7",
         "prettier": "^3.7.4",
+        "promise-port": "^1.0.1",
         "rollup": "^4.53.3",
         "selfsigned": "^5.2.0"
       },
@@ -1491,26 +1489,6 @@
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-react-jsx": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.27.1.tgz",
-      "integrity": "sha512-2KH4LWGSrJIkVf5tSiBFYuXDAoWRq2MMwgivCf+93dd0GQi8RXLjKA/0EvRnVV5G0hrHczsquXuD01L8s6dmBw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.27.1",
-        "@babel/helper-module-imports": "^7.27.1",
-        "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/plugin-syntax-jsx": "^7.27.1",
-        "@babel/types": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -6776,16 +6754,6 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/babel-plugin-jsx-pragmatic": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jsx-pragmatic/-/babel-plugin-jsx-pragmatic-1.0.2.tgz",
-      "integrity": "sha512-+qeGXSbHZwinZzO6R3wP+6XDKup83Pgg2B3TQt2zwfDdgC7NqT9Kd3ws7iqk53zAO/8iOIRU6VUyUzt2LDE3Eg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "babel-plugin-syntax-jsx": "^6.0.0"
-      }
-    },
     "node_modules/babel-plugin-polyfill-corejs2": {
       "version": "0.4.14",
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.14.tgz",
@@ -6827,13 +6795,6 @@
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
       }
-    },
-    "node_modules/babel-plugin-syntax-jsx": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-      "integrity": "sha512-qrPaCSo9c8RHNRHIotaufGbuOBN8rtdC4QrrFFc43vyWCCz7Kl7GL1PGaXtMGQZUXrkCjNEgxDfmAuAabr/rlw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/babel-preset-current-node-syntax": {
       "version": "1.2.0",
@@ -15756,6 +15717,13 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/promise-port": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/promise-port/-/promise-port-1.0.1.tgz",
+      "integrity": "sha512-C3OxFrV+hH+ZTru48dHjI6qRCq+4eTbLVTu80/ig03Nvs703rzQbo+dHrI5tp/cDckSTfPNULottEwVKZje0zQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/promise-retry": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -3,17 +3,14 @@
   "type": "module",
   "devDependencies": {
     "@babel/core": "^7.28.5",
-    "@babel/plugin-transform-modules-commonjs": "^7.27.1",
-    "@babel/plugin-transform-react-jsx": "^7.27.1",
     "@babel/plugin-transform-runtime": "^7.28.5",
     "@babel/preset-env": "^7.28.5",
     "@babel/runtime": "^7.28.4",
+    "@jest/globals": "^30.2.0",
     "@rollup/plugin-babel": "^6.1.0",
     "@rollup/plugin-commonjs": "^29.0.0",
     "@rollup/plugin-node-resolve": "^16.0.3",
     "@rollup/plugin-terser": "^0.4.4",
-    "babel-jest": "^30.2.0",
-    "babel-plugin-jsx-pragmatic": "^1.0.2",
     "bytes": "^3.1.2",
     "eslint": "^9.39.1",
     "eslint-config-prettier": "^10.1.8",
@@ -31,12 +28,13 @@
     "lerna": "^9.0.3",
     "lint-staged": "^16.2.7",
     "prettier": "^3.7.4",
+    "promise-port": "^1.0.1",
     "rollup": "^4.53.3",
     "selfsigned": "^5.2.0"
   },
   "scripts": {
-    "test": "node ./node_modules/.bin/jest --forceExit",
-    "e2e": "NODE_TLS_REJECT_UNAUTHORIZED=0 node ./node_modules/.bin/jest --forceExit --runInBand --config e2e.config.cjs",
+    "test": "node --experimental-vm-modules ./node_modules/.bin/jest --forceExit",
+    "e2e": "NODE_TLS_REJECT_UNAUTHORIZED=0 node --experimental-vm-modules ./node_modules/.bin/jest --forceExit --runInBand --config e2e.config.cjs",
     "preversion": "make bundle"
   },
   "engines": {

--- a/packages/client-core/test/Client.js
+++ b/packages/client-core/test/Client.js
@@ -1,4 +1,4 @@
-import { JID } from "@xmpp/test";
+import { JID, xml } from "@xmpp/test";
 
 import Client from "../lib/Client.js";
 
@@ -36,17 +36,17 @@ test("header", () => {
 
   entity.jid = null;
   entity.isSecure = () => false;
-  expect(entity.header(<foo />)).toEqual(<foo />);
+  expect(entity.header(xml("foo"))).toEqual(xml("foo"));
 
   entity.jid = null;
   entity.isSecure = () => true;
-  expect(entity.header(<foo />)).toEqual(<foo />);
+  expect(entity.header(xml("foo"))).toEqual(xml("foo"));
 
   entity.jid = new JID("foo@bar/example");
   entity.isSecure = () => false;
-  expect(entity.header(<foo />)).toEqual(<foo />);
+  expect(entity.header(xml("foo"))).toEqual(xml("foo"));
 
   entity.jid = new JID("foo@bar/example");
   entity.isSecure = () => true;
-  expect(entity.header(<foo />)).toEqual(<foo from="foo@bar" />);
+  expect(entity.header(xml("foo"))).toEqual(xml("foo", { from: "foo@bar" }));
 });

--- a/packages/connection/test/_closeStream.js
+++ b/packages/connection/test/_closeStream.js
@@ -1,3 +1,4 @@
+import { jest } from "@jest/globals";
 import { EventEmitter, promise, TimeoutError } from "@xmpp/events";
 import { xml } from "@xmpp/test";
 

--- a/packages/connection/test/disconnect.js
+++ b/packages/connection/test/disconnect.js
@@ -1,3 +1,6 @@
+import { jest } from "@jest/globals";
+import { xml } from "@xmpp/test";
+
 import Connection from "../index.js";
 
 test("disconnect", async () => {
@@ -69,7 +72,7 @@ test("disconnect with _closeStream and _closeSocket rejections", async () => {
 
 test("resolves if socket property is undefined", async () => {
   const conn = new Connection();
-  conn.footerElement = () => <foo />;
+  conn.footerElement = () => xml("foo");
   conn.socket = undefined;
   await conn.disconnect();
   expect().pass();

--- a/packages/connection/test/onElement.js
+++ b/packages/connection/test/onElement.js
@@ -1,10 +1,11 @@
-import xml from "@xmpp/xml";
+import { jest } from "@jest/globals";
+import { xml } from "@xmpp/test";
 
 import Connection from "../index.js";
 
 test("#_onElement", (done) => {
   expect.assertions(2);
-  const foo = <foo />;
+  const foo = xml("foo");
   const conn = new Connection();
   conn.on("element", (el) => {
     expect(el).toBe(foo);

--- a/packages/connection/test/parserError.js
+++ b/packages/connection/test/parserError.js
@@ -1,3 +1,4 @@
+import { jest } from "@jest/globals";
 import { EventEmitter } from "@xmpp/events";
 
 import Connection from "../index.js";

--- a/packages/connection/test/socketClose.js
+++ b/packages/connection/test/socketClose.js
@@ -1,3 +1,4 @@
+import { jest } from "@jest/globals";
 import { EventEmitter } from "@xmpp/events";
 
 import Connection from "../index.js";

--- a/packages/connection/test/stop.js
+++ b/packages/connection/test/stop.js
@@ -1,3 +1,4 @@
+import { jest } from "@jest/globals";
 import { EventEmitter } from "@xmpp/events";
 
 import Connection from "../index.js";

--- a/packages/connection/test/streamError.js
+++ b/packages/connection/test/streamError.js
@@ -1,3 +1,4 @@
+import { jest } from "@jest/globals";
 import xml from "@xmpp/xml";
 
 import Connection from "../index.js";

--- a/packages/jid/test/index.js
+++ b/packages/jid/test/index.js
@@ -1,3 +1,5 @@
+import { jest } from "@jest/globals";
+
 import jid, { equal, JID } from "../index.js";
 
 test("equal calls equals on the first argument with the second argument", () => {

--- a/packages/middleware/test/Context.js
+++ b/packages/middleware/test/Context.js
@@ -1,3 +1,5 @@
+import { xml } from "@xmpp/test";
+
 import Context from "../lib/Context.js";
 
 test("sets the entity property", () => {
@@ -7,13 +9,13 @@ test("sets the entity property", () => {
 });
 
 test("sets the stanza property", () => {
-  const stanza = <presence />;
+  const stanza = xml("presence");
   const ctx = new Context({}, stanza);
   expect(ctx.stanza).toBe(stanza);
 });
 
 test("sets name, id and type properties", () => {
-  const stanza = <message id="foobar" type="whatever" />;
+  const stanza = xml("message", { id: "foobar", type: "whatever" });
   const ctx = new Context({}, stanza);
   expect(ctx.name).toBe("message");
   expect(ctx.id).toBe("foobar");
@@ -21,56 +23,56 @@ test("sets name, id and type properties", () => {
 });
 
 test("id property defaults to empty string", () => {
-  const stanza = <message />;
+  const stanza = xml("message");
   const ctx = new Context({}, stanza);
   expect(ctx.id).toBe("");
 });
 
 test("type property defaults to normal for message", () => {
-  const stanza = <message />;
+  const stanza = xml("message");
   const ctx = new Context({}, stanza);
   expect(ctx.type).toBe("normal");
 });
 
 test("type property defaults to available for presence", () => {
-  const stanza = <presence />;
+  const stanza = xml("presence");
   const ctx = new Context({}, stanza);
   expect(ctx.type).toBe("available");
 });
 
 test("type property defaults to empty string for iq", () => {
-  const stanza = <iq />;
+  const stanza = xml("iq");
   const ctx = new Context({}, stanza);
   expect(ctx.type).toBe("");
 });
 
 test("type property defaults to empty string for nonzas", () => {
-  const stanza = <foobar />;
+  const stanza = xml("foobar");
   const ctx = new Context({}, stanza);
   expect(ctx.type).toBe("");
 });
 
 test("to property is null", () => {
-  const ctx = new Context({}, <foobar />);
+  const ctx = new Context({}, xml("foobar"));
   expect(ctx.to).toBe(null);
 });
 
 test("from property is null", () => {
-  const ctx = new Context({}, <foobar />);
+  const ctx = new Context({}, xml("foobar"));
   expect(ctx.from).toBe(null);
 });
 
 test("local property is an empty string", () => {
-  const ctx = new Context({}, <foobar />);
+  const ctx = new Context({}, xml("foobar"));
   expect(ctx.local).toBe("");
 });
 
 test("domain property is an empty string", () => {
-  const ctx = new Context({}, <foobar />);
+  const ctx = new Context({}, xml("foobar"));
   expect(ctx.domain).toBe("");
 });
 
 test("resource property is an empty string", () => {
-  const ctx = new Context({}, <foobar />);
+  const ctx = new Context({}, xml("foobar"));
   expect(ctx.resource).toBe("");
 });

--- a/packages/middleware/test/middleware.js
+++ b/packages/middleware/test/middleware.js
@@ -1,4 +1,4 @@
-import { context, mockClient, mockInput, promiseError } from "@xmpp/test";
+import { context, mockClient, mockInput, promiseError, xml } from "@xmpp/test";
 
 import IncomingContext from "../lib/IncomingContext.js";
 import OutgoingContext from "../lib/OutgoingContext.js";
@@ -14,7 +14,7 @@ beforeEach(() => {
 
 test("use", (done) => {
   expect.assertions(4);
-  const stanza = <presence />;
+  const stanza = xml("presence");
   ctx.middleware.use((ctx, next) => {
     expect(ctx instanceof IncomingContext).toBe(true);
     expect(ctx.stanza).toEqual(stanza);
@@ -27,7 +27,7 @@ test("use", (done) => {
 
 test("filter", (done) => {
   expect.assertions(3);
-  const stanza = <presence />;
+  const stanza = xml("presence");
   ctx.middleware.filter((ctx, next) => {
     expect(ctx instanceof OutgoingContext).toBe(true);
     expect(ctx.stanza).toEqual(stanza);
@@ -49,7 +49,7 @@ test("emits an error event if a middleware throws", async () => {
     throw error;
   });
 
-  mockInput(xmpp, <presence id="hello" />);
+  mockInput(xmpp, xml("presence", { id: "hello" }));
 
   const err = await willError;
   expect(err).toEqual(error);

--- a/packages/websocket/test/test.js
+++ b/packages/websocket/test/test.js
@@ -1,3 +1,4 @@
+import { jest } from "@jest/globals";
 import { EventEmitter } from "@xmpp/events";
 import xml from "@xmpp/xml";
 

--- a/test/browser.js
+++ b/test/browser.js
@@ -3,9 +3,9 @@ import { readFileSync } from "node:fs";
 
 import { JSDOM } from "jsdom";
 
-import { jid } from "./packages/client/index.js";
-import debug from "./packages/debug/index.js";
-import server from "./server/index.js";
+import { jid } from "../packages/client/index.js";
+import debug from "../packages/debug/index.js";
+import server from "../server/index.js";
 
 const username = "client";
 const password = "foobar";


### PR DESCRIPTION
Simplifies tests tooling and unlocks moving away from Jest.