### PR TITLE
Added enabled Event to stream management

### DIFF
--- a/packages/stream-management/index.js
+++ b/packages/stream-management/index.js
@@ -111,6 +111,7 @@ export default function streamManagement({
     // > The counter for the received stanzas ('h') is set to zero and started after receiving either <enable/> or <enabled/>.
     // https://xmpp.org/extensions/xep-0198.html#example-7
     sm.inbound = 0;
+    sm.emit("enabled")
     scheduleRequestAck();
   }
 


### PR DESCRIPTION
Currently when following the example the presence stanza is send before the session management is enabled. It can be beneficial to have the presence stanza in the session management to make sure it is received by the server. To make this possible I added an extra event emitted from the stream management called enabled.